### PR TITLE
Support max memory size and max vcpus amount

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,26 +53,26 @@ he_source_email: root@localhost
 
 he_bridge_if: eth0
 he_fqdn: engine.example.com
-he_mem_size_MB: 4096
-he_vcpus: 4
-he_disk_size_GB: 50
+he_mem_size_MB: max
+he_vcpus: max
+he_disk_size_GB: 61
 
 he_enable_libgfapi: false
 he_enable_hc_gluster_service: false
 he_vm_mac_addr: null
 
-## Create storage domain vars:
+## Storage domain vars:
 he_domain_type: null # can be: nfs | iscsi | gluster | fc
 he_storage_domain_addr: null
 
 ## NFS vars:
-## Defaults are null, user should specify if NFS is choosen
+## Defaults are null, user should specify if NFS is chosen
 he_mount_options: ''
 he_storage_domain_path: null
 he_nfs_version: auto # can be: auto, v4 or v3
 
 ## ISCSI vars:
-## Defaults are null, user should specify if ISCSI is choosen
+## Defaults are null, user should specify if ISCSI is chosen
 he_iscsi_username: null
 he_iscsi_password: null
 he_iscsi_discover_username: null
@@ -88,5 +88,5 @@ he_discard: false
 he_vm_ip_addr: null
 he_vm_ip_prefix: null
 he_dns_addr: null # up to 3 DNS servers IPs can be added
-he_vm_etc_hosts: false # try default of '' . user can add lines to /etc/hosts on the engine VM
+he_vm_etc_hosts: false # user can add lines to /etc/hosts on the engine VM
 he_default_gateway: null

--- a/tasks/pre_checks/validate_memory_size.yml
+++ b/tasks/pre_checks/validate_memory_size.yml
@@ -16,6 +16,12 @@
     register: max_mem
   - debug: var=max_mem
 
+- name: set he_mem_size_MB to max available if not defined
+  set_fact:
+    he_mem_size_MB: "{{ he_mem_size_MB if he_mem_size_MB != 'max' else max_mem }}"
+  register: he_mem_size_MB
+- debug: var=he_mem_size_MB
+
 - name: Fail if available memory is less then the minimal requirement
   fail:
     msg: "Available memory ( {{ max_mem }}MB ) is less then the minimal requirement ({{ he_minimal_mem_size_MB }}MB)"

--- a/tasks/pre_checks/validate_vcpus_count.yml
+++ b/tasks/pre_checks/validate_vcpus_count.yml
@@ -10,6 +10,12 @@
     register: he_maxvcpus
   - debug: var=he_maxvcpus
 
+- name: Set he_vcpus to maximum amount if not defined
+  set_fact:
+    he_vcpus: "{{ he_vcpus if he_vcpus != 'max' else he_maxvcpus }}"
+  register: he_vcpus
+- debug: var=he_vcpus
+
 - name: Check number of chosen CPUs
   fail:
     msg: "Invalid number of cpu specified: {{ he_vcpus }}, while only {{ he_maxvcpus }} are available on the host"


### PR DESCRIPTION
Max memory size and max vcpus amount can be defined when using
the 'max' keyword.

Using max memory size and max vcpus amount is the default