### PR TITLE
cockpit wizard specific fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ No.
 | Name                            | Default value         |  Description                                              |
 |---------------------------------|-----------------------|-----------------------------------------------------------|
 | he_bridge_if | eth0 | The network interface ovirt management bridge will be configured on |
-| he_fqdn | engine.example.com | The engine FQDN as it configured on the DNS |
+| he_fqdn | null | The engine FQDN as it configured on the DNS |
 | he_mem_size_MB | max | The amount of memory used on the engine VM |
 | he_vcpus | max | The amount of CPUs used on the engine VM |
 | he_disk_size_GB | 61 | Disk size of the engine VM |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,7 @@ he_source_email: root@localhost
 ## Mandatory variables:
 
 he_bridge_if: eth0
-he_fqdn: engine.example.com
+he_fqdn: null
 he_mem_size_MB: max
 he_vcpus: max
 he_disk_size_GB: 61

--- a/tasks/pre_checks/002_validate_hostname_tasks.yml
+++ b/tasks/pre_checks/002_validate_hostname_tasks.yml
@@ -1,5 +1,5 @@
 ---
-- name: Define he_host_name
+- name: Define he_host_name if not defined
   block:
   - name: Get full hostname
     command: hostname -f
@@ -9,6 +9,7 @@
     set_fact:
       he_host_name: "{{ host_full_name.stdout_lines[0] }}"
     register: he_host_name
+  when: he_host_name is none
 - debug: var=he_host_name
 
 - name: Validate host hostname
@@ -91,7 +92,7 @@
           only there.
       when: hostname_res_count_output.stdout_lines|length > 1
     when: he_bridge_if is defined and he_mgmt_network is defined
-  when: he_host_name is defined
+  when: he_host_name is defined and he_host_name is not none
 - name: Validate engine he_fqdn
   block:
   - name: Avoid localhost
@@ -131,4 +132,5 @@
     with_items:
       - "http://{{ he_fqdn }}/"
       - "https://{{ he_fqdn }}/"
-  when: he_fqdn is defined
+  when: he_fqdn is defined and he_fqdn is not none
+


### PR DESCRIPTION
cockpit wizard calls more than once the role to validate
host hostname and engine fqdn.
Correctly support that.