### PR TITLE
Add requirements check variable for testing purposes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,3 +100,8 @@ he_vm_ip_prefix: null
 he_dns_addr: null # up to 3 DNS servers IPs can be added
 he_vm_etc_hosts: false # user can add lines to /etc/hosts on the engine VM
 he_default_gateway: null
+
+# *** Do Not Use On Production Environment ***
+# ********** Used for testing ONLY ***********
+he_requirements_check_enabled: True
+he_memory_requirements_check_enabled: True

--- a/tasks/pre_checks/validate_memory_size.yml
+++ b/tasks/pre_checks/validate_memory_size.yml
@@ -25,12 +25,12 @@
 - name: Fail if available memory is less then the minimal requirement
   fail:
     msg: "Available memory ( {{ max_mem }}MB ) is less then the minimal requirement ({{ he_minimal_mem_size_MB }}MB)"
-  when: max_mem|int < he_minimal_mem_size_MB|int
+  when: he_requirements_check_enabled and he_memory_requirements_check_enabled and max_mem|int < he_minimal_mem_size_MB|int
 
 - name: Fail if user chose less memory then the minimal requirement
   fail:
     msg: "Memory size must be at least {{ he_minimal_mem_size_MB }}MB, while you selected only {{ he_mem_size_MB }}MB"
-  when: he_minimal_mem_size_MB|int > he_mem_size_MB|int
+  when: he_requirements_check_enabled and he_memory_requirements_check_enabled and he_minimal_mem_size_MB|int > he_mem_size_MB|int
 
 - name: Fail if user chose more memory then the available memory
   fail:
@@ -40,4 +40,4 @@
 - name: Fail if he_disk_size_GB is smaller then the minimal requirement
   fail:
     msg: "Disk size too small: ({{ he_disk_size_GB }}GB), disk size must be at least {{ he_minimal_disk_size_GB }}GB"
-  when: he_disk_size_GB|int < he_minimal_disk_size_GB|int
+  when: he_requirements_check_enabled and he_disk_size_GB|int < he_minimal_disk_size_GB|int


### PR DESCRIPTION
The variable can be used for testing hosted-engine
with less resources than the minimum requirement.

The variable's value should be changed to 'False'
only on testing enviroments and not for production.


Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>