### PR TITLE
Fix Ansible warnings

### DIFF
--- a/hooks/after_setup/README.md
+++ b/hooks/after_setup/README.md
@@ -1,0 +1,3 @@
+# USAGE
+
+Place here playbooks to be executed after hosted-engine-setup finishes.

--- a/hooks/enginevm_after_engine_setup/README.md
+++ b/hooks/enginevm_after_engine_setup/README.md
@@ -1,0 +1,3 @@
+# USAGE
+
+Place here playbooks to be executed on the engine VM after engine-setup finishes.

--- a/hooks/enginevm_before_engine_setup/README.md
+++ b/hooks/enginevm_before_engine_setup/README.md
@@ -1,0 +1,3 @@
+# USAGE
+
+Place here playbooks to be executed on the engine VM before engine-setup starts.

--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -67,7 +67,7 @@
     async: 1
     poll: 0
   - name: Wait for the host to be up
-    ovirt_hosts_facts:
+    ovirt_host_facts:
       pattern: name={{ he_host_name }}
       auth: "{{ ovirt_auth }}"
     register: host_result_up_check

--- a/tasks/create_storage_domain.yml
+++ b/tasks/create_storage_domain.yml
@@ -11,7 +11,7 @@
     when: not local_vm_dir_stat.stat.exists
   - include_tasks: auth_sso.yml
   - name: Fetch host facts
-    ovirt_hosts_facts:
+    ovirt_host_facts:
       pattern: name={{ he_host_name }}
       auth: "{{ ovirt_auth }}"
     register: host_result
@@ -36,7 +36,7 @@
   - name: Fetch Datacenter name
     set_fact: datacenter_name={{ ovirt_datacenters|json_query("[?id=='" + datacenter_id + "'].name")|first }}
   - name: Add NFS storage domain
-    ovirt_storage_domains:
+    ovirt_storage_domain:
       state: unattached
       name: "{{ he_storage_domain_name }}"
       host: "{{ he_host_name }}"
@@ -51,7 +51,7 @@
     when: he_domain_type == "nfs"
     register: otopi_storage_domain_details_nfs
   - name: Add glusterfs storage domain
-    ovirt_storage_domains:
+    ovirt_storage_domain:
       state: unattached
       name: "{{ he_storage_domain_name }}"
       host: "{{ he_host_name }}"
@@ -69,7 +69,7 @@
     when: he_domain_type == "glusterfs"
     register: otopi_storage_domain_details_gluster
   - name: Add iSCSI storage domain
-    ovirt_storage_domains:
+    ovirt_storage_domain:
       state: unattached
       name: "{{ he_storage_domain_name }}"
       host: "{{ he_host_name }}"
@@ -92,7 +92,7 @@
     when: he_domain_type == "iscsi"
     register: otopi_storage_domain_details_iscsi
   - name: Add Fibre Channel storage domain
-    ovirt_storage_domains:
+    ovirt_storage_domain:
       state: unattached
       name: "{{ he_storage_domain_name }}"
       host: "{{ he_host_name }}"
@@ -105,7 +105,7 @@
     register: otopi_storage_domain_details_fc
     when: he_domain_type == "fc"
   - name: Get storage domain details
-    ovirt_storage_domains_facts:
+    ovirt_storage_domain_facts:
       pattern: name={{ he_storage_domain_name }}
       auth: "{{ ovirt_auth }}"
     register: storage_domain_details
@@ -134,7 +134,7 @@
     set_fact: required_size="{{ disk_size_xml.matches[0].Disk['{http://schemas.dmtf.org/ovf/envelope/1/}size']|int * 1024 * 1024 * 1024 + storage_domain_details.ansible_facts.ovirt_storage_domains[0].critical_space_action_blocker|int * 1024 * 1024 * 1024 + 5 * 1024 * 1024 * 1024}}" # +5G: 2xOVF_STORE, lockspace, metadata, configuration
   - debug: var=required_size
   - name: Remove unsuitable storage domain
-    ovirt_storage_domains:
+    ovirt_storage_domain:
       host: "{{ he_host_name }}"
       data_center: "{{ datacenter_name }}"
       name: "{{ he_storage_domain_name }}"
@@ -151,7 +151,7 @@
             If you wish to use the current target storage domain by extending it, make sure it contains nothing before adding it."
     when: storage_domain_details.ansible_facts.ovirt_storage_domains[0].available|int < required_size|int
   - name: Activate storage domain
-    ovirt_storage_domains:
+    ovirt_storage_domain:
       host: "{{ he_host_name }}"
       data_center: "{{ datacenter_name }}"
       name: "{{ he_storage_domain_name }}"

--- a/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -17,7 +17,7 @@
     changed_when: True
   - debug: var=local_vm_ip
   - name: Fetch host facts
-    ovirt_hosts_facts:
+    ovirt_host_facts:
       pattern: name={{ he_host_name }} status=up
       auth: "{{ ovirt_auth }}"
     register: host_result
@@ -90,7 +90,7 @@
     set_fact:
       emulated_machine: emulated_machine_list.json['values']['system_option_value'][0]['value'].replace('[','').replace(']','').split(', ')|first
   - name: Get storage domain details
-    ovirt_storage_domains_facts:
+    ovirt_storage_domain_facts:
       pattern: name={{ he_storage_domain_name }} and datacenter={{ datacenter_name }}
       auth: "{{ ovirt_auth }}"
     register: storage_domain_details
@@ -121,7 +121,7 @@
       he_metadata_disk_details: "{{ add_disks.results[3] }}"
   - debug: var=add_disks
   - name: Add VM
-    ovirt_vms:
+    ovirt_vm:
       state: stopped
       cluster: "{{ cluster_name }}"
       name: "{{ he_vm_name }}"

--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -3,17 +3,17 @@
   block:
   # workaround for https://bugzilla.redhat.com/1590943
   - name: Enable again the serial console device
-    ovirt_vms:
+    ovirt_vm:
       id: "{{ he_vm_details.vm.id }}"
       serial_console: True
       auth: "{{ ovirt_auth }}"
   - name: Trigger hosted engine OVF update
-    ovirt_vms:
+    ovirt_vm:
       id: "{{ he_vm_details.vm.id }}"
       description: "Hosted engine VM"
       auth: "{{ ovirt_auth }}"
   - name: Wait until OVF update finishes
-    ovirt_storage_domains_facts:
+    ovirt_storage_domain_facts:
       auth: "{{ ovirt_auth }}"
       fetch_nested: True
       nested_attributes:
@@ -303,7 +303,7 @@
   # the engine fails deleting a VM if its status in the engine DB
   # is not up to date.
   - name: Check for the local bootstrap VM
-    ovirt_vms_facts:
+    ovirt_vm_facts:
       pattern: id="{{ external_local_vm_uuid.stdout_lines|first }}"
       auth: "{{ ovirt_auth }}"
     register: local_vm_f
@@ -311,14 +311,14 @@
     block:
       - name: Make the engine aware that the external VM is stopped
         ignore_errors: yes
-        ovirt_vms:
+        ovirt_vm:
           state: stopped
           id: "{{ external_local_vm_uuid.stdout_lines|first }}"
           auth: "{{ ovirt_auth }}"
         register: vmstop_result
       - debug: var=vmstop_result
       - name: Wait for the local bootstrap VM to be down at engine eyes
-        ovirt_vms_facts:
+        ovirt_vm_facts:
           pattern: id="{{ external_local_vm_uuid.stdout_lines|first }}"
           auth: "{{ ovirt_auth }}"
         register: local_vm_status
@@ -327,7 +327,7 @@
         delay: 5
       - debug: var=local_vm_status
       - name: Remove bootstrap external VM from the engine
-        ovirt_vms:
+        ovirt_vm:
           state: absent
           id: "{{ external_local_vm_uuid.stdout_lines|first }}"
           auth: "{{ ovirt_auth }}"

--- a/tasks/iscsi_discover.yml
+++ b/tasks/iscsi_discover.yml
@@ -9,7 +9,7 @@
         username: "{{ he_iscsi_discover_username }}"
         password: "{{ he_iscsi_discover_password }}"
 - name: Fetch host facts
-  ovirt_hosts_facts:
+  ovirt_host_facts:
     pattern: name={{ he_host_name }}
     auth: "{{ ovirt_auth }}"
   register: host_result

--- a/tasks/pre_checks/001_validate_network_interfaces.yml
+++ b/tasks/pre_checks/001_validate_network_interfaces.yml
@@ -3,62 +3,68 @@
   block:
   - name: Detecting interface on existing management bridge
     set_fact:
-      bridge_interface="{{ hostvars[inventory_hostname]['ansible_' + item ]['interfaces']|first }}"
-    when: "'ansible_' + item in hostvars[inventory_hostname]"
+      bridge_interface="{{ hostvars[inventory_hostname]['ansible_' + bridge_name ]['interfaces']|first }}"
+    when: "'ansible_' + bridge_name in hostvars[inventory_hostname]"
     with_items:
       - 'ovirtmgmt'
       - 'rhevm'
+    loop_control:
+      loop_var: bridge_name
   - debug: var=bridge_interface
   - name: Get all active network interfaces
     vars:
       acceptable_bond_modes: ['active-backup','balance-xor','broadcast','802.3ad']
     set_fact:
-      otopi_net_host="{{ item }}"
-      type="{{ hostvars[inventory_hostname]['ansible_' + item]['type'] }}"
-      bond_valid_name="{{ item | regex_search('(^bond[0-9]+)') }}"
+      otopi_net_host="{{ iface_item }}"
+      type="{{ hostvars[inventory_hostname]['ansible_' + iface_item]['type'] }}"
+      bond_valid_name="{{ iface_item | regex_search('(^bond[0-9]+)') }}"
     when: (
         (
-          item != 'lo'
+          iface_item != 'lo'
         ) and (
           bridge_interface is not defined
         ) and (
-          'active' in hostvars[inventory_hostname]['ansible_' + item] and
-          hostvars[inventory_hostname]['ansible_' + item]['active']
+          'active' in hostvars[inventory_hostname]['ansible_' + iface_item] and
+          hostvars[inventory_hostname]['ansible_' + iface_item]['active']
         ) and (
-          hostvars[inventory_hostname]['ansible_' + item]['type'] != 'bridge'
+          hostvars[inventory_hostname]['ansible_' + iface_item]['type'] != 'bridge'
         ) and (
-          hostvars[inventory_hostname]['ansible_' + item]['ipv4'] is defined or
-          hostvars[inventory_hostname]['ansible_' + item]['ipv6'] is defined
+          hostvars[inventory_hostname]['ansible_' + iface_item]['ipv4'] is defined or
+          hostvars[inventory_hostname]['ansible_' + iface_item]['ipv6'] is defined
         ) and (
           (
-            hostvars[inventory_hostname]['ansible_' + item]['type'] != 'bonding'
+            hostvars[inventory_hostname]['ansible_' + iface_item]['type'] != 'bonding'
           ) or (
             (
-              hostvars[inventory_hostname]['ansible_' + item]['type'] == 'bonding'
+              hostvars[inventory_hostname]['ansible_' + iface_item]['type'] == 'bonding'
             ) and (
-              hostvars[inventory_hostname]['ansible_' + item]['slaves'][0] is defined
+              hostvars[inventory_hostname]['ansible_' + iface_item]['slaves'][0] is defined
             ) and (
-              hostvars[inventory_hostname]['ansible_' + item]['mode'] in acceptable_bond_modes
+              hostvars[inventory_hostname]['ansible_' + iface_item]['mode'] in acceptable_bond_modes
             )
           )
         )
       )
     with_items:
       - "{{ ansible_interfaces | map('replace', '-','_') | list }}"
+    loop_control:
+      loop_var: iface_item
     register: valid_network_interfaces
   - debug: var=valid_network_interfaces
   - name: Filter bonds with bad naming
     set_fact:
-      net_iface="{{ item }}"
+      net_iface="{{ bond_item }}"
     when:
-      not 'skipped' in item and ((item['ansible_facts']['type']  == 'ether') or ( (item['ansible_facts']['type'] == 'bonding') and (item['ansible_facts']['bond_valid_name'] != '')))
+      not 'skipped' in bond_item and ((bond_item['ansible_facts']['type']  == 'ether') or ( (bond_item['ansible_facts']['type'] == 'bonding') and (bond_item['ansible_facts']['bond_valid_name'] != '')))
     with_items:
       - "{{ valid_network_interfaces['results'] }}"
+    loop_control:
+      loop_var: bond_item
     register: bb_filtered_list
   - debug: var=bb_filtered_list
   - name: Generate output list
     set_fact:
-       otopi_host_net: "{{ [bridge_interface] if bridge_interface is defined else bb_filtered_list.results | reject('skipped') | map(attribute='item.item') | list }}"
+       otopi_host_net: "{{ [bridge_interface] if bridge_interface is defined else bb_filtered_list.results | reject('skipped') | map(attribute='bond_item.iface_item') | list }}"
     register: otopi_host_net
   - debug: var=otopi_host_net
   - name: Validate selected bridge interface if management bridge does not exists

--- a/tasks/pre_checks/validate_services_status.yml
+++ b/tasks/pre_checks/validate_services_status.yml
@@ -1,10 +1,12 @@
 ---
 - name: Populate service facts
   systemd:
-    name: "{{ item }}"
+    name: "{{ service_item }}"
   register: checked_services
   with_items:
     - firewalld
+  loop_control:
+    loop_var: service_item
 - fail:
     msg: "{{ service.name }} is masked or not running"
   when: service.status.SubState != 'running' or service.status.LoadState == 'masked'


### PR DESCRIPTION
1. Use loop_var in specific places
2. Change names of deprecated modules
3. Add missing paths - create hooks dir and subfolders

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>