### PR TITLE
Set OvfUpdateIntervalInMinutes config to 1 during deploy

### DIFF
--- a/tasks/bootstrap_local_vm/04_engine_final_tasks.yml
+++ b/tasks/bootstrap_local_vm/04_engine_final_tasks.yml
@@ -19,13 +19,20 @@
     changed_when: True
     when: he_enable_libgfapi
   - debug: var=libgfapi_support_out
-  - name: Restart ovirt-engine service for LibgfApi support
+  - name: Save original OvfUpdateIntervalInMinutes
+    shell: "engine-config -g OvfUpdateIntervalInMinutes | cut -d' ' -f2 > /root/OvfUpdateIntervalInMinutes.txt"
+    environment: "{{ he_cmd_lang }}"
+    changed_when: True
+  - name: Set OVF update interval to 1 minute
+    command: engine-config -s OvfUpdateIntervalInMinutes=1
+    environment: "{{ he_cmd_lang }}"
+    changed_when: True
+  - name: Restart ovirt-engine service for changed OVF Update configuration and LibgfApi support
     systemd:
       state: restarted
       name: ovirt-engine
-    register: restart_libgfapi_support_out
-    when: he_enable_libgfapi
-  - debug: var=restart_libgfapi_support_out
+    register: restart_out
+  - debug: var=restart_out
   - name: Mask cloud-init services to speed up future boot
     systemd:
       masked: yes

--- a/tasks/create_target_vm/02_engine_vm_configuration.yml
+++ b/tasks/create_target_vm/02_engine_vm_configuration.yml
@@ -44,3 +44,12 @@
       path: /root/DisableFenceAtStartupInSec.txt
       state: absent
     when: he_restore_from_file is defined and he_restore_from_file
+  - name: Restore original OvfUpdateIntervalInMinutes
+    command: "engine-config -s OvfUpdateIntervalInMinutes=$(cat /root/OvfUpdateIntervalInMinutes.txt)"
+    environment: "{{ he_cmd_lang }}"
+    changed_when: True
+  - name: Remove OvfUpdateIntervalInMinutes temporary file
+    file:
+      path: /root/OvfUpdateIntervalInMinutes.txt
+      state: absent
+    changed_when: True


### PR DESCRIPTION
The deploy script waits until the OVF file is written to the storage domain. Sometimes, probably because of a race, the OVF write is not triggered by update VM and the deploy script would have to wait for 60 minutes.

This patch changes the setting during the deploy, so the OVF is stored every minute.

Bug-Url: https://bugzilla.redhat.com/1644748