### PR TITLE
prevent host identification from known_hosts file

### DIFF
--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -6,7 +6,7 @@
       name: "{{ he_fqdn }}"
       groups: engine
       ansible_connection: smart
-      ansible_ssh_extra_args: '-o StrictHostKeyChecking=no {% if he_ansible_host_name != "localhost" %} -o ProxyCommand="ssh -W %h:%p -q root@{{ he_ansible_host_name }}" {% endif %}'
+      ansible_ssh_extra_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %} -o ProxyCommand="ssh -W %h:%p -q root@{{ he_ansible_host_name }}" {% endif %}'
       ansible_ssh_pass: "{{ he_appliance_password }}"
       ansible_user: root
   - name: Initial tasks

--- a/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -6,7 +6,7 @@
       name: "{{ he_fqdn }}"
       groups: engine
       ansible_connection: smart
-      ansible_ssh_extra_args: '-o StrictHostKeyChecking=no {% if he_ansible_host_name != "localhost" %} -o ProxyCommand="ssh -W %h:%p -q root@{{ he_ansible_host_name }}" {% endif %}'
+      ansible_ssh_extra_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %} -o ProxyCommand="ssh -W %h:%p -q root@{{ he_ansible_host_name }}" {% endif %}'
       ansible_ssh_pass: "{{ he_appliance_password }}"
       ansible_user: root
   - include_tasks: auth_sso.yml


### PR DESCRIPTION
In case of deploying the same host from ansible controller after host reprovision
we will fail with the error:
ssh_exchange_identification: Connection closed by remote host"
because the key in known_hosts changed after reprovision so we have to
prevent this identification by adding the parameter -o UserKnownHostsFile=/dev/null.