### PR TITLE
Add a flag for ovirt-hosted-engine-setup installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,6 +101,9 @@ he_dns_addr: null # up to 3 DNS servers IPs can be added
 he_vm_etc_hosts: false # user can add lines to /etc/hosts on the engine VM
 he_default_gateway: null
 
+# ovirt-hosted-engine-setup variables
+he_just_collect_network_interfaces: false
+
 # *** Do Not Use On Production Environment ***
 # ********** Used for testing ONLY ***********
 he_requirements_check_enabled: True

--- a/tasks/pre_checks/001_validate_network_interfaces.yml
+++ b/tasks/pre_checks/001_validate_network_interfaces.yml
@@ -70,5 +70,5 @@
   - name: Validate selected bridge interface if management bridge does not exists
     fail:
       msg: The selected network interface is not valid
-    when: he_bridge_if not in otopi_host_net and bridge_interface is not defined
+    when: he_bridge_if not in otopi_host_net and bridge_interface is not defined and not he_just_collect_network_interfaces
 ...


### PR DESCRIPTION
Add a flag to skip the interface check when the setup use the code
of 001_validate_network_interfaces to collect all the valid available
network interfaces for the user to choose from.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>