### PR TITLE
introduce tags for the hosted-engine deployment

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,25 +53,26 @@
   - name: Final clean
     include_tasks: final_clean.yml
     when: he_final_clean
+  tags: ['full_setup','never']
 
 - name: Sub-Stages for interactive setup execution
   block:
   - name: Validate network interface
     include_tasks: "pre_checks/001_validate_network_interfaces.yml"
-    when: he_pre_checks_network
+    tags: ['he_pre_checks_network','never']
 
   - name: Validate hostnames
     include_tasks: "pre_checks/002_validate_hostname_tasks.yml"
-    when: he_pre_checks_validate_hostnames
+    tags: ['he_pre_checks_validate_hostnames','never']
 
   - name: Get FC devices
     include_tasks: "fc_getdevices.yml"
-    when: he_setup_fc_getdevices
+    tags: ['he_setup_fc_getdevices','never']
 
   - name: iSCSI discover
     include_tasks: "iscsi_discover.yml"
-    when: he_setup_iscsi_discover
+    tags: ['he_setup_iscsi_discover','never']
 
   - name: Get iSCSI devices
     include_tasks: "iscsi_getdevices.yml"
-    when: he_setup_iscsi_getdevices
+    tags: ['he_setup_iscsi_getdevices','never']


### PR DESCRIPTION
Introduce a 'full_setup' tag for a full hosted-engine deployment
and other tags for specific validations and tasks for the CLI flow in ovirt-hosted-engine-setup

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>