### PR TITLE
remove the redundant parameter ovirt_engine_setup_accept_defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ All the playbooks can be found inside the `examples/` folder.
     ovirt_engine_setup_firewall_manager: null
     ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
     ovirt_engine_setup_use_remote_answer_file: True
-    ovirt_engine_setup_accept_defaults: True
     ovirt_engine_setup_update_all_packages: false
     ovirt_engine_setup_offline: true
     ovirt_engine_setup_admin_password: "{{ he_admin_password }}"
@@ -216,7 +215,6 @@ All the playbooks can be found inside the `examples/` folder.
     ovirt_engine_setup_firewall_manager: null
     ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
     ovirt_engine_setup_use_remote_answer_file: True
-    ovirt_engine_setup_accept_defaults: True
     ovirt_engine_setup_update_all_packages: false
     ovirt_engine_setup_offline: true
     ovirt_engine_setup_admin_password: "{{ he_admin_password }}"

--- a/examples/hosted_engine_deploy_localhost.yml
+++ b/examples/hosted_engine_deploy_localhost.yml
@@ -34,7 +34,6 @@
     ovirt_engine_setup_firewall_manager: null
     ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
     ovirt_engine_setup_use_remote_answer_file: true
-    ovirt_engine_setup_accept_defaults: true
     ovirt_engine_setup_update_all_packages: false
     ovirt_engine_setup_offline: true
     ovirt_engine_setup_admin_password: "{{ he_admin_password }}"

--- a/examples/hosted_engine_deploy_remotehost.yml
+++ b/examples/hosted_engine_deploy_remotehost.yml
@@ -33,7 +33,6 @@
     ovirt_engine_setup_firewall_manager: null
     ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
     ovirt_engine_setup_use_remote_answer_file: true
-    ovirt_engine_setup_accept_defaults: true
     ovirt_engine_setup_update_all_packages: false
     ovirt_engine_setup_offline: true
     ovirt_engine_setup_admin_password: "{{ he_admin_password }}"


### PR DESCRIPTION
in continuouse to PR "Fix upgrade flow":
  https://github.com/oVirt/ovirt-ansible-engine-setup/pull/35
need to remove the default value of ovirt_engine_setup_accept_defaults
since it's not in use anymore.