### PR TITLE
ansible-lint: skip 602

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+# see https://github.com/ansible/ansible-lint/issues/450
+# remove once galaxy will move to ansible-lint 4.0.1
+skip_list:
+  - '602'


### PR DESCRIPTION
skip 602 since in 4.0.0 it causes false positives
as for
https://github.com/ansible/ansible-lint/issues/450
Remove once galaxy will move to ansible-lint 4.0.1