### PR TITLE
Preparation for tags support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,21 +57,21 @@
 - name: Sub-Stages for interactive setup execution
   block:
     - name: Validate network interface
-      include_tasks: "pre_checks/001_validate_network_interfaces.yml"
+      import_tasks: "pre_checks/001_validate_network_interfaces.yml"
       when: he_pre_checks_network
 
     - name: Validate hostnames
-      include_tasks: "pre_checks/002_validate_hostname_tasks.yml"
+      import_tasks: "pre_checks/002_validate_hostname_tasks.yml"
       when: he_pre_checks_validate_hostnames
 
     - name: Get FC devices
-      include_tasks: "fc_getdevices.yml"
+      import_tasks: "fc_getdevices.yml"
       when: he_setup_fc_getdevices
 
     - name: iSCSI discover
-      include_tasks: "iscsi_discover.yml"
+      import_tasks: "iscsi_discover.yml"
       when: he_setup_iscsi_discover
 
     - name: Get iSCSI devices
-      include_tasks: "iscsi_getdevices.yml"
+      import_tasks: "iscsi_getdevices.yml"
       when: he_setup_iscsi_getdevices


### PR DESCRIPTION
Using import_tasks intead of include_tasks so the imported tasks
can inherent the tags.