### PR TITLE
Fix rhbz1654697

### DIFF
--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -15,7 +15,13 @@
   - name: Initial tasks
     block:
       - name: Get host unique id
-        shell: if [ -e /etc/vdsm/vdsm.id ]; then cat /etc/vdsm/vdsm.id; else dmidecode -s system-uuid; fi;
+        shell: |
+           if [ -e /etc/vdsm/vdsm.id ];
+           then cat /etc/vdsm/vdsm.id;
+           else if [ -e /proc/device-tree/system-id ];
+           then cat /proc/device-tree/system-id; #ppc64le
+           else dmidecode -s system-uuid;
+           fi;
         environment: "{{ he_cmd_lang }}"
         changed_when: true
         register: unique_id_out

--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -16,12 +16,12 @@
     block:
       - name: Get host unique id
         shell: |
-           if [ -e /etc/vdsm/vdsm.id ];
-           then cat /etc/vdsm/vdsm.id;
-           elif [ -e /proc/device-tree/system-id ];
-           then cat /proc/device-tree/system-id; #ppc64le
-           else dmidecode -s system-uuid;
-           fi;
+          if [ -e /etc/vdsm/vdsm.id ];
+          then cat /etc/vdsm/vdsm.id;
+          elif [ -e /proc/device-tree/system-id ];
+          then cat /proc/device-tree/system-id; #ppc64le
+          else dmidecode -s system-uuid;
+          fi;
         environment: "{{ he_cmd_lang }}"
         changed_when: true
         register: unique_id_out

--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -18,7 +18,7 @@
         shell: |
            if [ -e /etc/vdsm/vdsm.id ];
            then cat /etc/vdsm/vdsm.id;
-           else if [ -e /proc/device-tree/system-id ];
+           elif [ -e /proc/device-tree/system-id ];
            then cat /proc/device-tree/system-id; #ppc64le
            else dmidecode -s system-uuid;
            fi;


### PR DESCRIPTION
Fix rhbz1654697 by not using dmidecode on ppc64le where /proc/device-tree/system-id provides the UUID.
For reference: https://github.com/oVirt/vdsm/blob/master/lib/vdsm/ppc64HardwareInfo.py

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1654697
Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>