### PR TITLE
Making the bootstrap engine temporarily

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ he_mgmt_network: ovirtmgmt
 he_storage_domain_name: hosted_storage
 he_ansible_host_name: localhost
 he_ipv6_subnet_prefix: fd00:1234:5678:900
+he_webui_forward_port: 6900  # by default already open for VM console
 
 he_host_ip: null
 he_host_name: null

--- a/tasks/bootstrap_local_vm/04_engine_final_tasks.yml
+++ b/tasks/bootstrap_local_vm/04_engine_final_tasks.yml
@@ -27,6 +27,17 @@
     command: engine-config -s OvfUpdateIntervalInMinutes=1
     environment: "{{ he_cmd_lang }}"
     changed_when: true
+  - name: Allow the webadmin UI to be accessed over the first host
+    block:
+      - name: Saving original value
+        replace:
+          path: /etc/ovirt-engine/engine.conf.d/11-setup-sso.conf
+          regexp: '^(SSO_ALTERNATE_ENGINE_FQDNS=.*)'
+          replace: '#\1 # pre hosted-engine-setup'
+      - name: Adding new SSO_ALTERNATE_ENGINE_FQDNS line
+        lineinfile:
+          path: /etc/ovirt-engine/engine.conf.d/11-setup-sso.conf
+          line: 'SSO_ALTERNATE_ENGINE_FQDNS="{{ he_host_address }}" # hosted-engine-setup'
   - name: Restart ovirt-engine service for changed OVF Update configuration and LibgfApi support
     systemd:
       state: restarted

--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -10,6 +10,29 @@
     retries: 30
     delay: 20
   - debug: var=engine_status
+  - name: Open a port on firewalld
+    firewalld:
+      port: "{{ he_webui_forward_port }}/tcp"
+      permanent: false
+      immediate: true
+      state: enabled
+  - name: Expose engine VM webui over a local port via ssh port forwarding
+    command: >-
+      sshpass -e ssh -tt -o ServerAliveInterval=5 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -g -L
+      {{ he_webui_forward_port }}:{{ he_fqdn }}:443 {{ he_fqdn }}
+    environment:
+      - "{{ he_cmd_lang }}"
+      - SSHPASS: "{{ he_appliance_password }}"
+    changed_when: true
+    async: 86400
+    poll: 0
+    register: sshpf
+  - debug: var=sshpf
+  - name: Evaluate temporary bootstrap engine URL
+    set_fact: bootstrap_engine_url="https://{{ he_host_address }}:{{ he_webui_forward_port }}/ovirt-engine/"
+  - debug:
+      msg: >-
+        The bootstrap engine is temporary accessible over {{ bootstrap_engine_url }}
   - name: Detect VLAN ID
     shell: ip -d link show {{ he_bridge_if }} | grep 'vlan ' | grep -Po 'id \K[\d]+' | cat
     environment: "{{ he_cmd_lang }}"

--- a/tasks/create_target_vm/02_engine_vm_configuration.yml
+++ b/tasks/create_target_vm/02_engine_vm_configuration.yml
@@ -62,3 +62,15 @@
       path: /root/OvfUpdateIntervalInMinutes.txt
       state: absent
     changed_when: true
+  - name: Restore original SSO_ALTERNATE_ENGINE_FQDNS
+    block:
+      - name: Removing temporary value
+        lineinfile:
+          path: /etc/ovirt-engine/engine.conf.d/11-setup-sso.conf
+          regexp: '^SSO_ALTERNATE_ENGINE_FQDNS=.* # hosted-engine-setup'
+          state: absent
+      - name: Restoring original value
+        replace:
+          path: /etc/ovirt-engine/engine.conf.d/11-setup-sso.conf
+          regexp: '^#(SSO_ALTERNATE_ENGINE_FQDNS=.*) # pre hosted-engine-setup'
+          replace: '\1'


### PR DESCRIPTION
accessible over a custom port on the first
host via ssh port forwarding for troubleshooting