### PR TITLE
Trying to fetch engine logs only if local_vm_disk_path is defined

### DIFF
--- a/tasks/fetch_engine_logs.yml
+++ b/tasks/fetch_engine_logs.yml
@@ -25,3 +25,4 @@
   with_items:
     - /var/log/ovirt-engine
     - /var/log/messages
+  when: local_vm_disk_path is defined


### PR DESCRIPTION
Trying to fetch engine logs only if local_vm_disk_path is defined to avoid polluting execution logs on failures