### PR TITLE
Remove ovirt_repo_release_rpm from example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ he_admin_password: 123456
     "he_vm_mac_addr": "00:a5:3f:66:ba:12",
     "he_domain_type": "nfs",
     "he_storage_domain_addr": "192.168.100.50",
-    "he_storage_domain_path": "/var/nfs_folder",
-    "ovirt_repo_release_rpm": "http://plain.resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm"
+    "he_storage_domain_path": "/var/nfs_folder"
 }
 ```
 

--- a/examples/nfs_deployment.json
+++ b/examples/nfs_deployment.json
@@ -4,6 +4,5 @@
     "he_vm_mac_addr": "00:a5:3f:66:ba:12",
     "he_domain_type": "nfs",
     "he_storage_domain_addr": "192.168.100.50",
-    "he_storage_domain_path": "/var/nfs_folder",
-    "ovirt_repo_release_rpm": "http://plain.resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm"
+    "he_storage_domain_path": "/var/nfs_folder"
 }


### PR DESCRIPTION
The variable ovirt_repo_release_rpm is not used anymore.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>