### PR TITLE
Restore inital libvirt default network

### DIFF
--- a/tasks/initial_clean.yml
+++ b/tasks/initial_clean.yml
@@ -59,6 +59,11 @@
       - ovirt-ha-agent
       - ovirt-ha-broker
       - vdsmd
+  - name: Restore initial libvirt default network configuration
+    copy:
+      remote_src: true
+      src: /usr/share/libvirt/networks/default.xml
+      dest: /etc/libvirt/qemu/networks/default.xml
   - name: Start libvirt
     service:
       name: libvirtd


### PR DESCRIPTION
Restore inital libvirt default network
configuraiton on initial clean to be sure we
are not going to hit letfovers from
previous deploy attempts