### PR TITLE
Fix SD free space check before activation

### DIFF
--- a/tasks/create_storage_domain.yml
+++ b/tasks/create_storage_domain.yml
@@ -134,7 +134,8 @@
       required_size: >-
         {{ disk_size_xml.matches[0].Disk['{http://schemas.dmtf.org/ovf/envelope/1/}size']|int * 1024 * 1024 * 1024 +
         storage_domain_details.ansible_facts.ovirt_storage_domains[0].critical_space_action_blocker|int *
-        1024 * 1024 * 1024 + 5 * 1024 * 1024 * 1024 }} # +5G: 2xOVF_STORE, lockspace, metadata, configuration
+        1024 * 1024 * 1024 + 5 * 1024 * 1024 * 1024 }}
+    # +5G: 2xOVF_STORE, lockspace, metadata, configuration
   - debug: var=required_size
   - name: Remove unsuitable storage domain
     ovirt_storage_domain:


### PR DESCRIPTION
If the storage domain is too small, with this I correctly see:
[ INFO  ] TASK [ovirt.hosted_engine_setup : Get required size]
[ INFO  ] ok: [localhost]
[ INFO  ] TASK [ovirt.hosted_engine_setup : Remove unsuitable storage domain]
[ INFO  ] changed: [localhost]
[ INFO  ] TASK [ovirt.hosted_engine_setup : Check storage domain free space]
[ ERROR ] fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error: the target storage domain contains only 58.0GiB of available space while a minimum of 61.0GiB is required If you wish to use the current target storage domain by extending it, make sure it contains nothing before adding it."}

while without this the required size got incorrectly computed as
"65498251264 # +5G: 2xOVF_STORE, lockspace, metadata, configuration" that ansible *magically* consumes as 0 without any warning when used with '|int' 
