### PR TITLE
if ANSIBLE_HOST_KEY_CHECKING=False add StrictHostKeyChecking=no option to ProxyCommand

### DIFF
--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -1,6 +1,9 @@
 ---
 - name: Create hosted engine local vm
   block:
+  - name: Fetch the value of HOST_KEY_CHECKING
+    set_fact: host_key_checking="{{ lookup('config', 'HOST_KEY_CHECKING') }}"
+  - debug: var=host_key_checking
   - name: Register the engine FQDN as a host
     add_host:
       name: "{{ he_fqdn }}"
@@ -8,7 +11,9 @@
       ansible_connection: smart
       ansible_ssh_extra_args: >-
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %}
-        -o ProxyCommand="ssh -W %h:%p -q root@{{ he_ansible_host_name }}" {% endif %}
+        -o ProxyCommand="ssh -W %h:%p -q
+        {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
+        root@{{ he_ansible_host_name }}" {% endif %}
       ansible_ssh_pass: "{{ he_appliance_password }}"
       ansible_user: root
     no_log: true

--- a/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -1,6 +1,9 @@
 ---
 - name: Create target Hosted Engine VM
   block:
+  - name: Fetch the value of HOST_KEY_CHECKING
+    set_fact: host_key_checking="{{ lookup('config', 'HOST_KEY_CHECKING') }}"
+  - debug: var=host_key_checking
   - name: Register the engine FQDN as a host
     add_host:
       name: "{{ he_fqdn }}"
@@ -8,7 +11,9 @@
       ansible_connection: smart
       ansible_ssh_extra_args: >-
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %}
-        -o ProxyCommand="ssh -W %h:%p -q root@{{ he_ansible_host_name }}" {% endif %}
+        -o ProxyCommand="ssh -W %h:%p -q
+        {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
+        root@{{ he_ansible_host_name }}" {% endif %}
       ansible_ssh_pass: "{{ he_appliance_password }}"
       ansible_user: root
     no_log: true


### PR DESCRIPTION
in case of ANSIBLE_HOST_KEY_CHECKING=False on the ansible controller we want to set the
ProxyCommand with StrictHostKeyChecking=no and UserKnownHostsFile=/dev/null

we need it because when we run ansible (on the same environment which reprovisioned) from same ansible controller we failed with the following error:
timed out waiting for ping module test success: Failed to connect to the host via ssh: ssh_exchange_identification: Connection closed by remote host 

or run manually on the ansible conntroller:
ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand="ssh -W %h:%p -q root@{{ he_ansible_host_name }}"  root@{{ he_fqdn }}
get:
ssh_exchange_identification: Connection closed by remote host

when removing the host from known_host file or add the StrictHostKeyChecking=no 
we will be able to run ansible without the above error.