### PR TITLE
ignore errors on libvirt net-undefine on IPv6

### DIFF
--- a/tasks/libvirt_default_net_ipv6_tasks.yml
+++ b/tasks/libvirt_default_net_ipv6_tasks.yml
@@ -56,6 +56,7 @@
   virt_net:
     command: undefine
     name: default
+  ignore_errors: true
 - name: Update libvirt default network configuration, define
   virt_net:
     command: define


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-ansible-hosted-engine-setup/issues/127

Normally the right sequence should be 
virsh net-destroy default
virsh net-undefine default

but form some strange reason sometimes the network is already undefined as a result of the destroy command: ignoring errors on net-undefine