### PR TITLE
cloud-init: using openscap to remediate HE VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ No.
 | he_host_name | $(hostname -f) | name used by the engine for the first host |
 | he_host_address | $(hostname -f) | address used by the engine for the first host |
 | he_bridge_if | null | interface used for the management bridge |
+| he_apply_openscap_profile | false | apply a default OpenSCAP security profile on HE VM |
 
 ## NFS / Gluster Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ he_local_vm_dir_prefix: localvm
 he_appliance_ova: ''
 he_root_ssh_pubkey: ''
 he_root_ssh_access: 'yes'
+he_apply_openscap_profile: false
 he_cdrom: ''
 he_console_type: vnc
 he_video_device: vga

--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -94,6 +94,28 @@
         command: openssl passwd -1 {{ he_appliance_password }}
         register: he_hashed_appliance_password
         no_log: true
+      - block:
+          - name: Initialize OpenSCAP variables
+            set_fact:
+              oscap_dir: "/usr/share/xml/scap/ssg/content"
+              oscap_dist: "{{ ansible_distribution | replace('RedHat', 'rhel') | lower }}"
+              oscap_ver: "{{ ansible_distribution_major_version if ansible_distribution != 'Fedora' else '' }}"
+          - name: Set OpenSCAP datastream path
+            set_fact:
+              oscap_datastream: "{{ oscap_dir }}/ssg-{{ oscap_dist }}{{ oscap_ver }}-ds.xml"
+          - debug: var=oscap_datastream
+          - name: Verify OpenSCAP datastream
+            stat:
+              path: "{{ oscap_datastream }}"
+            register: oscap_ds_stat
+          - name: Set default OpenSCAP profile
+            shell: >-
+                oscap info --profiles {{ oscap_datastream }} |
+                grep -Ei "(standard|disa)" | sort | tail -1 | cut -d':' -f1
+            register: oscap_profile
+            when: oscap_ds_stat.stat.exists
+          - debug: var=oscap_profile
+        when: he_apply_openscap_profile
       - name: Create cloud init user-data and meta-data files
         template:
           src: "{{ item.src }}"

--- a/templates/user-data.j2
+++ b/templates/user-data.j2
@@ -13,8 +13,10 @@ chpasswd:
 {% if he_time_zone is defined %}
 timezone: {{ he_time_zone }}
 {% endif %}
-bootcmd:
+runcmd:
+{% if he_apply_openscap_profile and oscap_profile.stdout|length > 1 and oscap_datastream|length > 1 %}
+  - oscap xccdf eval --profile {{ oscap_profile.stdout }} --remediate --report /root/openscap-report.html {{ oscap_datastream }}
+{% endif %}
   - if grep -Gq "^\s*PermitRootLogin" /etc/ssh/sshd_config; then sed -re "s/^\s*(PermitRootLogin)\s+(yes|no|without-password)/\1 {{ he_root_ssh_access }}/" -i.$(date -u +%Y%m%d%H%M%S) /etc/ssh/sshd_config; else echo "PermitRootLogin {{ he_root_ssh_access }}" >> /etc/ssh/sshd_config; fi
   - if grep -Gq "^\s*UseDNS" /etc/ssh/sshd_config; then sed -re "s/^\s*(UseDNS)\s+(yes|no)/\1 no/" -i.$(date -u +%Y%m%d%H%M%S) /etc/ssh/sshd_config; else echo "UseDNS no" >> /etc/ssh/sshd_config; fi
-runcmd:
   - systemctl restart sshd &


### PR DESCRIPTION
When the user chooses to apply an OpenSCAP security profile, the
cloud-init script will remediate the HostedEngine VM according to the
selected profile

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1392051
Signed-off-by: Yuval Turgeman <yturgema@redhat.com>