### PR TITLE
Avoid installing appliance rpm if not installed

### DIFF
--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -7,6 +7,3 @@
   until: task_result is success
   retries: 10
   delay: 2
-
-- name: Install engine appliance
-  include_tasks: install_appliance.yml


### PR DESCRIPTION
Appliance rpm is already going to be installed,
only if really needed, due to
https://github.com/oVirt/ovirt-ansible-hosted-engine-setup/blob/master/tasks/bootstrap_local_vm/02_create_local_vm.yml#L49

no need to replicate it in tasks/install_packages.yml

Fixes: https://bugzilla.redhat.com/1691173