### PR TITLE
Forcing to avoid the use of become on locally delegated tasks

### DIFF
--- a/tasks/initial_clean.yml
+++ b/tasks/initial_clean.yml
@@ -108,4 +108,5 @@
       name: "{{ he_fqdn }}"
       state: absent
     delegate_to: localhost
+    become: false
 ...


### PR DESCRIPTION
locally delegated tasks.

The whole role can be also executed with
delegate_to: root as a regular
user on the ansible controller node.

Cleaning up .ssh/know_hosts for
leftovers on the ansible controller
should happen as current user also in that case.

Fixes: https://github.com/oVirt/ovirt-ansible-hosted-engine-setup/issues/143