### PR TITLE
Access the ssh proxy host with the right user

### DIFF
--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -4,6 +4,11 @@
   - name: Fetch the value of HOST_KEY_CHECKING
     set_fact: host_key_checking="{{ lookup('config', 'HOST_KEY_CHECKING') }}"
   - debug: var=host_key_checking
+  - name: Get the username running the deploy
+    become: false
+    command: whoami
+    delegate_to: localhost
+    register: username_on_controller
   - name: Register the engine FQDN as a host
     add_host:
       name: "{{ he_fqdn }}"
@@ -13,7 +18,7 @@
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %}
         -o ProxyCommand="ssh -W %h:%p -q
         {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
-        root@{{ he_ansible_host_name }}" {% endif %}
+        {{ username_on_controller.stdout }}@{{ he_ansible_host_name }}" {% endif %}
       ansible_ssh_pass: "{{ he_appliance_password }}"
       ansible_user: root
     no_log: true

--- a/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -4,6 +4,11 @@
   - name: Fetch the value of HOST_KEY_CHECKING
     set_fact: host_key_checking="{{ lookup('config', 'HOST_KEY_CHECKING') }}"
   - debug: var=host_key_checking
+  - name: Get the username running the deploy
+    become: false
+    command: whoami
+    delegate_to: localhost
+    register: username_on_controller
   - name: Register the engine FQDN as a host
     add_host:
       name: "{{ he_fqdn }}"
@@ -13,7 +18,7 @@
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %}
         -o ProxyCommand="ssh -W %h:%p -q
         {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
-        root@{{ he_ansible_host_name }}" {% endif %}
+        {{ username_on_controller.stdout }}@{{ he_ansible_host_name }}" {% endif %}
       ansible_ssh_pass: "{{ he_appliance_password }}"
       ansible_user: root
     no_log: true


### PR DESCRIPTION
The user can deploy on a remote host running
ansible-playbook as a regular user just with become
root on the whole role.
Accessing the proxy host with the right user.

Fixes: https://github.com/oVirt/ovirt-ansible-hosted-engine-setup/issues/155