### PR TITLE
Fix Openssl and FIPS issue

### DIFF
--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -96,8 +96,8 @@
         register: otopi_appliance_disk_size
       - debug: var=virtual_size
       - name: Hash the appliance root password
-        command: openssl passwd -1 "{{ he_appliance_password }}"
-        register: he_hashed_appliance_password
+        set_fact:
+          he_hashed_appliance_password: "{{ he_appliance_password | string | password_hash('sha512') }}"
         no_log: true
       - block:
           - name: Initialize OpenSCAP variables

--- a/templates/user-data.j2
+++ b/templates/user-data.j2
@@ -8,7 +8,7 @@ ssh_authorized_keys:
 ssh_pwauth: True
 chpasswd:
   list: |
-    root:{{ he_hashed_appliance_password.stdout }}
+    root:{{ he_hashed_appliance_password }}
   expire: False
 {% if he_time_zone is defined %}
 timezone: {{ he_time_zone }}


### PR DESCRIPTION
When FIPS is enabled Openssl exit with Segmentation Fault when
executed with certain options.
Thus, encypting the appliance password using Python's crypt
module.

Bug-Url: https://bugzilla.redhat.com/1694034
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>