### PR TITLE
Using DNS to check connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ No.
 | he_host_address | $(hostname -f) | address used by the engine for the first host |
 | he_bridge_if | null | interface used for the management bridge |
 | he_apply_openscap_profile | false | apply a default OpenSCAP security profile on HE VM |
+| he_network_test| dns | the way of the network connectivity check performed by ovirt-hosted-engine-ha and ovirt-hosted-engine-setup, available options: *dns*, *ping*, *tcp* or *none*.  |
+| tcp_t_address| null | hostname to connect if he_network_test is *tcp*  |
+| tcp_t_port| null | port to connect if he_network_test is *tcp* |
 
 ## NFS / Gluster Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,6 +87,9 @@ he_vm_ip_prefix: null
 he_dns_addr: null  # up to 3 DNS servers IPs can be added
 he_vm_etc_hosts: false  # user can add lines to /etc/hosts on the engine VM
 he_default_gateway: null
+he_network_test: 'dns'  # can be: 'dns', 'ping', 'tcp' or 'none'
+he_tcp_t_address: null
+he_tcp_t_port: null
 
 # ovirt-hosted-engine-setup variables
 he_just_collect_network_interfaces: false

--- a/tasks/pre_checks/validate_network_test.yml
+++ b/tasks/pre_checks/validate_network_test.yml
@@ -1,0 +1,34 @@
+---
+- name: Validate network connectivity check configuration
+  block:
+  - debug: var=he_network_test
+  - name: Fail if he_network_test is not valid
+    fail:
+      msg: "Invalid he_network_test defined"
+    changed_when: true
+    when: he_network_test not in ['dns', 'ping', 'tcp', 'none']
+  - name: Validate TCP network connectivity check parameters
+    block:
+    - debug: var=he_tcp_t_address
+    - name: Fail if he_tcp_t_address is not defined
+      fail:
+        msg: "No he_tcp_t_address is defined"
+      changed_when: true
+      when:
+        ( he_tcp_t_address is undefined ) or
+        ( he_tcp_t_address is none ) or
+        ( he_tcp_t_address|trim == '' )
+    - debug: var=he_tcp_t_port
+    - name: Fail if he_tcp_t_port is not defined
+      fail:
+        msg: "No he_tcp_t_port is defined"
+      changed_when: true
+      when:
+        ( he_tcp_t_port is undefined ) or
+        ( he_tcp_t_port is none )
+    - name: Fail if he_tcp_t_port is no integer
+      fail:
+        msg: "he_tcp_t_port has to be integer"
+      changed_when: true
+      when: not he_tcp_t_port|int
+    when: he_network_test == 'tcp'

--- a/templates/hosted-engine.conf.j2
+++ b/templates/hosted-engine.conf.j2
@@ -25,6 +25,9 @@ ca_subject="C=EN, L=Test, O=Test, CN=Test"
 vdsm_use_ssl=true
 gateway={{ he_gateway }}
 bridge={{ he_mgmt_network }}
+network_test={{ he_network_test }}
+tcp_t_address={{ he_tcp_t_address }}
+tcp_t_port={{ he_tcp_t_port }}
 metadata_volume_UUID={{ he_metadata_disk_details.disk.image_id }}
 metadata_image_UUID={{ he_metadata_disk_details.disk.id }}
 lockspace_volume_UUID={{ he_sanlock_disk_details.disk.image_id }}


### PR DESCRIPTION
On new installations, DNS is used to check network
connectivity.

Bug-Url: https://bugzilla.redhat.com/1659052

PR to get feedback, not yet verified.