### PR TITLE
openscap: move oscap remediation to ansible

### DIFF
--- a/tasks/apply_openscap_profile.yml
+++ b/tasks/apply_openscap_profile.yml
@@ -1,0 +1,32 @@
+---
+- name: Initialize OpenSCAP variables
+  set_fact:
+    oscap_dir: "/usr/share/xml/scap/ssg/content"
+    oscap_dist: "{{ ansible_distribution | replace('RedHat', 'rhel') | lower }}"
+    oscap_ver: "{{ ansible_distribution_major_version if ansible_distribution != 'Fedora' else '' }}"
+- name: Set OpenSCAP datastream path
+  set_fact:
+    oscap_datastream: "{{ oscap_dir }}/ssg-{{ oscap_dist }}{{ oscap_ver }}-ds.xml"
+- debug: var=oscap_datastream
+- name: Verify OpenSCAP datastream
+  stat:
+    path: "{{ oscap_datastream }}"
+  register: oscap_ds_stat
+- name: Set default OpenSCAP profile
+  shell: >-
+    oscap info --profiles {{ oscap_datastream }} |
+    grep -Ei "(standard|disa)" | sort | tail -1 | cut -d':' -f1
+  register: oscap_profile
+  when: oscap_ds_stat.stat.exists
+- debug: var=oscap_profile
+- name: Apply OpenSCAP profile
+  shell: >-
+    oscap xccdf eval --profile {{ oscap_profile.stdout }} --remediate
+    --report /root/openscap-report.html {{ oscap_datastream }}
+  failed_when: false
+  ignore_errors: true
+- name: Reset PermitRootLogin for sshd
+  lineinfile: dest=/etc/ssh/sshd_config
+              regexp="^\s*PermitRootLogin"
+              line="PermitRootLogin {{ he_root_ssh_access }}"
+              state=present

--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -99,28 +99,6 @@
         set_fact:
           he_hashed_appliance_password: "{{ he_appliance_password | string | password_hash('sha512') }}"
         no_log: true
-      - block:
-          - name: Initialize OpenSCAP variables
-            set_fact:
-              oscap_dir: "/usr/share/xml/scap/ssg/content"
-              oscap_dist: "{{ ansible_distribution | replace('RedHat', 'rhel') | lower }}"
-              oscap_ver: "{{ ansible_distribution_major_version if ansible_distribution != 'Fedora' else '' }}"
-          - name: Set OpenSCAP datastream path
-            set_fact:
-              oscap_datastream: "{{ oscap_dir }}/ssg-{{ oscap_dist }}{{ oscap_ver }}-ds.xml"
-          - debug: var=oscap_datastream
-          - name: Verify OpenSCAP datastream
-            stat:
-              path: "{{ oscap_datastream }}"
-            register: oscap_ds_stat
-          - name: Set default OpenSCAP profile
-            shell: >-
-                oscap info --profiles {{ oscap_datastream }} |
-                grep -Ei "(standard|disa)" | sort | tail -1 | cut -d':' -f1
-            register: oscap_profile
-            when: oscap_ds_stat.stat.exists
-          - debug: var=oscap_profile
-        when: he_apply_openscap_profile|bool
       - name: Create cloud init user-data and meta-data files
         template:
           src: "{{ item.src }}"

--- a/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -37,6 +37,9 @@
     no_log: true
     with_items:
       - "OVESETUP_CONFIG/adminPassword=str:{{ he_admin_password }}"
+  - name: Import OpenSCAP task
+    import_tasks: apply_openscap_profile.yml
+    when: he_apply_openscap_profile|bool
   - name: Include before engine-setup custom tasks files for the engine VM
     include_tasks: "{{ item }}"
     with_fileglob: "hooks/enginevm_before_engine_setup/*.yml"

--- a/templates/user-data.j2
+++ b/templates/user-data.j2
@@ -13,10 +13,8 @@ chpasswd:
 {% if he_time_zone is defined %}
 timezone: {{ he_time_zone }}
 {% endif %}
-runcmd:
-{% if he_apply_openscap_profile and oscap_profile.stdout|length > 1 and oscap_datastream|length > 1 %}
-  - oscap xccdf eval --profile {{ oscap_profile.stdout }} --remediate --report /root/openscap-report.html {{ oscap_datastream }}
-{% endif %}
+bootcmd:
   - if grep -Gq "^\s*PermitRootLogin" /etc/ssh/sshd_config; then sed -re "s/^\s*(PermitRootLogin)\s+(yes|no|without-password)/\1 {{ he_root_ssh_access }}/" -i.$(date -u +%Y%m%d%H%M%S) /etc/ssh/sshd_config; else echo "PermitRootLogin {{ he_root_ssh_access }}" >> /etc/ssh/sshd_config; fi
   - if grep -Gq "^\s*UseDNS" /etc/ssh/sshd_config; then sed -re "s/^\s*(UseDNS)\s+(yes|no)/\1 no/" -i.$(date -u +%Y%m%d%H%M%S) /etc/ssh/sshd_config; else echo "UseDNS no" >> /etc/ssh/sshd_config; fi
+runcmd:
   - systemctl restart sshd &


### PR DESCRIPTION
- Running oscap remediation during cloud-init may be interrupted by
systemd.
- Reverting user-data to the way it was without oscap

Bug-Url: https://bugzilla.redhat.com/1392051
Signed-off-by: Yuval Turgeman <yturgema@redhat.com>