### PR TITLE
Fetch the username from remote host

### DIFF
--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -7,8 +7,7 @@
   - name: Get the username running the deploy
     become: false
     command: whoami
-    delegate_to: localhost
-    register: username_on_controller
+    register: username_on_host
   - name: Register the engine FQDN as a host
     add_host:
       name: "{{ he_fqdn }}"
@@ -18,7 +17,7 @@
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %}
         -o ProxyCommand="ssh -W %h:%p -q
         {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
-        {{ username_on_controller.stdout }}@{{ he_ansible_host_name }}" {% endif %}
+        {{ username_on_host.stdout }}@{{ he_ansible_host_name }}" {% endif %}
       ansible_ssh_pass: "{{ he_appliance_password }}"
       ansible_user: root
     no_log: true

--- a/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -7,8 +7,7 @@
   - name: Get the username running the deploy
     become: false
     command: whoami
-    delegate_to: localhost
-    register: username_on_controller
+    register: username_on_host
   - name: Register the engine FQDN as a host
     add_host:
       name: "{{ he_fqdn }}"
@@ -18,7 +17,7 @@
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% if he_ansible_host_name != "localhost" %}
         -o ProxyCommand="ssh -W %h:%p -q
         {% if not host_key_checking %} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {% endif %}
-        {{ username_on_controller.stdout }}@{{ he_ansible_host_name }}" {% endif %}
+        {{ username_on_host.stdout }}@{{ he_ansible_host_name }}" {% endif %}
       ansible_ssh_pass: "{{ he_appliance_password }}"
       ansible_user: root
     no_log: true


### PR DESCRIPTION
This should work:
- executing ansible-playbook as root deploying over a remote host
- executing ansible-playbook as unprivileged user with become = true on the whole role (and passwordless sudo rights on the remote host)
- executing ansible-playbook as unprivileged user but adding "-u root" on cmd line

Fixes: https://github.com/oVirt/ovirt-ansible-hosted-engine-setup/issues/178
