### PR TITLE
Add name validation for Cluster name and DC name

### DIFF
--- a/tasks/pre_checks/validate_data_center_name.yml
+++ b/tasks/pre_checks/validate_data_center_name.yml
@@ -1,0 +1,14 @@
+- name: Validate Data Center name format
+  block:
+  - name: Fail if Data Center name format is incorrect
+    fail:
+      msg: >-
+        "Invalid Data Center name format. Data Center name may only contain letters, numbers, '-', or '_'."
+        " Got {{ he_data_center }}"
+    when: not he_data_center | regex_search( "^[a-zA-Z0-9_-]+$" )
+  - name: Validate Cluster name
+    fail:
+      msg: >-
+        "Cluster name cannot be 'Default'. This is a reserved name for the default DataCenter. Please choose"
+        " another name for the cluster"
+    when: he_data_center != "Default" and he_cluster == "Default"


### PR DESCRIPTION
Deployment fail at the pre_checks stage if any of the
Cluster name or the Data Center name are not valid

Bug-Url: https://bugzilla.redhat.com/1705249
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>