### PR TITLE
Reserve small amount of memory for the host during deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ No.
 | he_bridge_if | eth0 | The network interface ovirt management bridge will be configured on |
 | he_fqdn | null | The engine FQDN as it configured on the DNS |
 | he_mem_size_MB | max | The amount of memory used on the engine VM |
+| he_reserved_memory_MB | 512 | The amount of memory reserved for the host |
 | he_vcpus | max | The amount of CPUs used on the engine VM |
 | he_disk_size_GB | 61 | Disk size of the engine VM |
 | he_vm_mac_addr | null | MAC address of the engine vm network interface. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ he_storage_domain_name: hosted_storage
 he_ansible_host_name: localhost
 he_ipv6_subnet_prefix: fd00:1234:5678:900
 he_webui_forward_port: 6900  # by default already open for VM console
+he_reserved_memory_MB: 512
 
 he_host_ip: null
 he_host_name: null

--- a/tasks/pre_checks/validate_memory_size.yml
+++ b/tasks/pre_checks/validate_memory_size.yml
@@ -13,7 +13,7 @@
   - debug: var=cached_mem
   - name: Set Max memory
     set_fact:
-      max_mem: "{{ free_mem.stdout|int + cached_mem.stdout|int }}"
+      max_mem: "{{ free_mem.stdout|int + cached_mem.stdout|int - he_reserved_memory_MB }}"
     register: max_mem
   - debug: var=max_mem
 
@@ -25,7 +25,10 @@
 
 - name: Fail if available memory is less then the minimal requirement
   fail:
-    msg: "Available memory ( {{ max_mem }}MB ) is less then the minimal requirement ({{ he_minimal_mem_size_MB }}MB)"
+    msg: >-
+     Available memory ( {{ max_mem }}MB ) is less then the minimal requirement ({{ he_minimal_mem_size_MB }}MB).
+     Be aware that {{ he_reserved_memory_MB }}MB is reserved for the host and cannot be allocated to the
+     engine VM.
   when: >-
     he_requirements_check_enabled and he_memory_requirements_check_enabled and max_mem|int < he_minimal_mem_size_MB|int
 
@@ -38,7 +41,11 @@
 
 - name: Fail if user chose more memory then the available memory
   fail:
-    msg: "Not enough memory: {{ he_mem_size_MB }}MB, while only {{ max_mem }}MB are available on the host"
+    msg: >-
+      Not enough memory! {{ he_mem_size_MB }}MB, while only {{ max_mem }}MB are available on the host.
+      Be aware that {{ he_reserved_memory_MB }}MB is reserved for the host and cannot be allocated to the
+      engine VM.
+
   when: he_mem_size_MB|int > max_mem|int
 
 - name: Fail if he_disk_size_GB is smaller then the minimal requirement


### PR DESCRIPTION
Reduce the maximum amount of memory the user can
assign to the engine VM during deployment.

Fixes: https://bugzilla.redhat.com/1704323
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>