### PR TITLE
Add small amount of memory to the total available memory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ he_ansible_host_name: localhost
 he_ipv6_subnet_prefix: fd00:1234:5678:900
 he_webui_forward_port: 6900  # by default already open for VM console
 he_reserved_memory_MB: 512
+he_avail_memory_grace_MB: 50
 
 he_host_ip: null
 he_host_name: null

--- a/tasks/pre_checks/validate_memory_size.yml
+++ b/tasks/pre_checks/validate_memory_size.yml
@@ -13,7 +13,7 @@
   - debug: var=cached_mem
   - name: Set Max memory
     set_fact:
-      max_mem: "{{ free_mem.stdout|int + cached_mem.stdout|int - he_reserved_memory_MB }}"
+      max_mem: "{{ free_mem.stdout|int + cached_mem.stdout|int - he_reserved_memory_MB + he_avail_memory_grace_MB }}"
     register: max_mem
   - debug: var=max_mem
 


### PR DESCRIPTION
When running the deployment through cockpit or
hosted-engine's CLI and choosing the maximum memory available
one might fail the installation in the pre_checks section
for 'Not Enough Memory' due to a slight difference between the available
memory calculated in cockpit/CLI to the calulation on Ansible that
occured afterwards.

Thus, adding a small amount of memory (50 MB) to the total available memory
will solve the problem.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>