### PR TITLE
Refresh the auth token after a long operation

### DIFF
--- a/tasks/auth_revoke.yml
+++ b/tasks/auth_revoke.yml
@@ -3,3 +3,4 @@
   ovirt_auth:
     state: absent
     ovirt_auth: "{{ ovirt_sso_auth }}"
+  ignore_errors: true

--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -108,6 +108,9 @@
             eventually remediate it, please continue only when the host is listed as 'up'
       - include_tasks: pause_execution.yml
     when: he_pause_host|bool
+  # refresh the auth token after a long operation to avoid having it expired
+  - include_tasks: auth_revoke.yml
+  - include_tasks: auth_sso.yml
   - name: Wait for the host to be up
     ovirt_host_facts:
       pattern: name={{ he_host_name }}


### PR DESCRIPTION
Refresh the auth token after a long operation
to avoid failing due to an expired token.

Fixes: https://bugzilla.redhat.com/1712667