### PR TITLE
Bind the engine VM to its disk by id

### DIFF
--- a/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -204,7 +204,7 @@
       # timezone: "{{ he_time_zone }}" # TODO: fix with the right parameter syntax
       storage_domain: "{{ he_storage_domain_name }}"
       disks:
-        - name: he_virtio_disk
+        - name: "{{ he_virtio_disk_details.disk.id }}"
       nics:
         - name: vnet0
           profile_name: "{{ he_mgmt_network }}"


### PR DESCRIPTION
Bind the engine VM to its disk by id and
not by name because on restore flow we
have to disks with the same name.

Fixes: https://bugzilla.redhat.com/1712667