### PR TITLE
retry on yum failures

### DIFF
--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -384,6 +384,10 @@
     yum:
       name: ovirt-engine-appliance
       state: absent
+    register: yum_result
+    until: yum_result is success
+    retries: 10
+    delay: 5
     when: he_remove_appliance_rpm|bool
 
   - name: Include custom tasks for after setup customization


### PR DESCRIPTION
yum module can temporary fail if
another process is already using yum
for periodic checks or similar.
Retry to avoid failing the whole
deployment just for that.