### PR TITLE
[RFR]Updating role to handle database and datawarehouse passwords if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ No.
 | he_offline_deployment | false | If `True`, updates for all packages will be disabled |
 | he_additional_package_list | [] | List of additional packages to be installed on engine VM apart from ovirt-engine package |
 | he_debug_mode | false | If `True`, HE deployment will execute additional tasks for debug |
-| he_admin_password| UNDEF | Password for admin user to login to RHV Manager UI |
 | he_db_password | UNDEF | Engine database password |
 | he_dwh_db_password | UNDEF | DWH database password |
 
@@ -120,6 +119,24 @@ All the playbooks can be found inside the `examples/` folder.
   hosts: host123.localdomain
   roles:
     - role: ovirt.hosted_engine_setup
+```
+
+## passwords.yml
+
+```yml
+---
+# As an example this file is keep in plaintext, if you want to
+# encrypt this file, please execute following command:
+#
+# $ ansible-vault encrypt passwords.yml
+#
+# It will ask you for a password, which you must then pass to
+# ansible interactively when executing the playbook.
+#
+# $ ansible-playbook myplaybook.yml --ask-vault-pass
+#
+he_appliance_password: 123456
+he_admin_password: 123456
 ```
 
 ## Example 1: extra vars for NFS deployment with DHCP - he_deployment.json

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ All the playbooks can be found inside the `examples/` folder.
 #
 he_appliance_password: 123456
 he_admin_password: 123456
+# Optionally you can define these variables given below
+# if you don't define them, ovirt_engine_setup generates random passwords for
+# database and datawarehouse
+ovirt_engine_setup_dwh_db_password: 123456 #optional variable, default to some random password
+ovirt_engine_setup_db_password: 123456     #optional variable, default to some random password
 ```
 
 ## Example 1: extra vars for NFS deployment with DHCP - he_deployment.json

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ No.
 | he_offline_deployment | false | If `True`, updates for all packages will be disabled |
 | he_additional_package_list | [] | List of additional packages to be installed on engine VM apart from ovirt-engine package |
 | he_debug_mode | false | If `True`, HE deployment will execute additional tasks for debug |
+| he_admin_password| UNDEF | Password for admin user to login to RHV Manager UI |
+| he_db_password | UNDEF | Engine database password |
+| he_dwh_db_password | UNDEF | DWH database password |
 
 ## NFS / Gluster Variables
 
@@ -117,29 +120,6 @@ All the playbooks can be found inside the `examples/` folder.
   hosts: host123.localdomain
   roles:
     - role: ovirt.hosted_engine_setup
-```
-
-## passwords.yml
-
-```yml
----
-# As an example this file is keep in plaintext, if you want to
-# encrypt this file, please execute following command:
-#
-# $ ansible-vault encrypt passwords.yml
-#
-# It will ask you for a password, which you must then pass to
-# ansible interactively when executing the playbook.
-#
-# $ ansible-playbook myplaybook.yml --ask-vault-pass
-#
-he_appliance_password: 123456
-he_admin_password: 123456
-# Optionally you can define these variables given below
-# if you don't define them, ovirt_engine_setup generates random passwords for
-# database and datawarehouse
-ovirt_engine_setup_dwh_db_password: 123456 #optional variable, default to some random password
-ovirt_engine_setup_db_password: 123456     #optional variable, default to some random password
 ```
 
 ## Example 1: extra vars for NFS deployment with DHCP - he_deployment.json

--- a/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -37,8 +37,8 @@
     no_log: true
     with_items:
       - "OVESETUP_CONFIG/adminPassword=str:{{ he_admin_password }}"
-      - "OVESETUP_DWH_DB/password=str:{{ ovirt_engine_setup_dwh_db_password }}"
-      - "OVESETUP_DB/password=str:{{ ovirt_engine_setup_db_password  }}"
+      - "OVESETUP_DWH_DB/password=str:{{ ovirt_engine_setup_dwh_db_password | default(omit) }}"
+      - "OVESETUP_DB/password=str:{{ ovirt_engine_setup_db_password | default(omit) }}"
   - name: Import OpenSCAP task
     import_tasks: apply_openscap_profile.yml
     when: he_apply_openscap_profile|bool

--- a/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -37,8 +37,22 @@
     no_log: true
     with_items:
       - "OVESETUP_CONFIG/adminPassword=str:{{ he_admin_password }}"
-      - "OVESETUP_DWH_DB/password=str:{{ ovirt_engine_setup_dwh_db_password | default(omit) }}"
+  - name: Add lines to answerfile
+    lineinfile:
+      path: /root/ovirt-engine-answers
+      line: "{{ item }}"
+    no_log: true
+    with_items:
       - "OVESETUP_DB/password=str:{{ ovirt_engine_setup_db_password | default(omit) }}"
+    when: ovirt_engine_setup_db_password is defined
+  - name: Add lines to answerfile
+    lineinfile:
+      path: /root/ovirt-engine-answers
+      line: "{{ item }}"
+    no_log: true
+    with_items:
+      - "OVESETUP_DWH_DB/password=str:{{ ovirt_engine_setup_dwh_db_password | default(omit) }}"
+    when: ovirt_engine_setup_dwh_db_password is defined
   - name: Import OpenSCAP task
     import_tasks: apply_openscap_profile.yml
     when: he_apply_openscap_profile|bool

--- a/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -37,6 +37,8 @@
     no_log: true
     with_items:
       - "OVESETUP_CONFIG/adminPassword=str:{{ he_admin_password }}"
+      - "OVESETUP_DWH_DB/password=str:{{ ovirt_engine_setup_dwh_db_password }}"
+      - "OVESETUP_DB/password=str:{{ ovirt_engine_setup_db_password  }}"
   - name: Import OpenSCAP task
     import_tasks: apply_openscap_profile.yml
     when: he_apply_openscap_profile|bool

--- a/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -43,16 +43,16 @@
       line: "{{ item }}"
     no_log: true
     with_items:
-      - "OVESETUP_DB/password=str:{{ ovirt_engine_setup_db_password | default(omit) }}"
-    when: ovirt_engine_setup_db_password is defined
+      - "OVESETUP_DB/password=str:{{ he_db_password }}"
+    when: he_db_password is defined
   - name: Add lines to answerfile
     lineinfile:
       path: /root/ovirt-engine-answers
       line: "{{ item }}"
     no_log: true
     with_items:
-      - "OVESETUP_DWH_DB/password=str:{{ ovirt_engine_setup_dwh_db_password | default(omit) }}"
-    when: ovirt_engine_setup_dwh_db_password is defined
+      - "OVESETUP_DWH_DB/password=str:{{ he_dwh_db_password }}"
+    when: he_dwh_db_password is defined
   - name: Import OpenSCAP task
     import_tasks: apply_openscap_profile.yml
     when: he_apply_openscap_profile|bool


### PR DESCRIPTION
Hello, 
While using this ansible role, I came across its shortcoming of not being able to set the DB and DWH passwords in the `/root/ovirt-engine-answers` file that it uses. Hence I decided to add those two password items to `lineinfile` call and the passwords can be defined in the passwords.yml as shown in README. Although, if left `UNDEF` we should still be able to deploy engine and it will generate and use some randomly generated password. Let me know how does it look? 
I have tested it in our env. (CFME QE)

-KK.