### PR TITLE
Search for an available subnet if current is used

### DIFF
--- a/tasks/search_available_network_subnet.yaml
+++ b/tasks/search_available_network_subnet.yaml
@@ -1,0 +1,60 @@
+---
+- name: Search for an available IPv4 subnet
+  block:
+    - name: Define 3rd chunk
+      set_fact:
+        chunk: 0
+      when: chunk is not defined
+    - name: Set 3rd chunk
+      set_fact:
+        chunk: "{{ chunk|int + 1 }}"
+    - debug: var=chunk
+    - name: get_ip_route
+      shell: ip route get 192.168.{{ chunk }}.1 | grep "via"
+      register: result
+    - debug: var=result
+    - name: Fail if can't find an available subnet
+      fail:
+        msg: >-
+          "Cannot find an available subnet for internal Libvirt network"
+          "Please set it to an unused subnet by adding the variable 'he_ipv4_subnet_prefix'"
+          "to the variable-file ( e.g. he_ipv4_subnet_prefix: '123.456.789' )."
+      when: result.stdout.find("via") == -1 and chunk|int > 253
+    - name: Set new IPv4 subnet prefix
+      set_fact:
+        he_ipv4_subnet_prefix: "192.168.{{ chunk }}"
+      when: result.stdout.find("via") != -1
+    - name: Search again with another prefix
+      include_tasks: search_available_network_subnet.yaml
+      when: result.stdout.find("via") == -1
+  when: not ipv6_deployment|bool
+
+- name: Search for an available IPv6 subnet
+  block:
+    - name: Define 3rd chunk
+      set_fact:
+        chunk: 1000
+      when: chunk is not defined
+    - name: Set 3rd chunk
+      set_fact:
+        chunk: "{{ chunk|int + 45 }}"  # 200 tries
+    - debug: var=chunk
+    - name: get_ip_route
+      shell: ip -6 route get fd00:1234:{{ chunk }}:900::1 | grep "via"
+      register: result
+    - debug: var=result
+    - name: Fail if can't find an available subnet
+      fail:
+        msg: >-
+          "Cannot find an available subnet for internal Libvirt network"
+          "Please set it to an unused subnet by adding the variable 'he_ipv6_subnet_prefix'"
+          "to the variable-file ( e.g. he_ipv6_subnet_prefix: 'fd00:9876:5432:900' )."
+      when: result.stdout.find("via") == -1 and chunk|int > 9900
+    - name: Set new IPv6 subnet prefix
+      set_fact:
+        he_ipv6_subnet_prefix: "fd00:1234:{{ chunk }}:900"
+      when: result.stdout.find("via") != -1
+    - name: Search again with another prefix
+      include_tasks: search_available_network_subnet.yaml
+      when: result.stdout.find("via") == -1
+  when: ipv6_deployment|bool

--- a/tasks/validate_ip_prefix.yml
+++ b/tasks/validate_ip_prefix.yml
@@ -3,29 +3,21 @@
   block:
     - name: IPv4 Validation
       block:
-        - name: Get IP route
+        - name: Get IPv4 route
           command: ip route get {{ he_ipv4_subnet_prefix + ".1" }}
           register: ip_route_result
         - debug: var=ip_route_result
         - name: Check if route exists
-          fail:
-            msg: >-
-              "Libvirt network subnet ({{ he_ipv4_subnet_prefix }}) is already in use."
-              "Please set it to an unused subnet by adding the variable 'he_ipv4_subnet_prefix'"
-              "to the variable-file. ( e.g. he_ipv4_subnet_prefix: '192.168.153' )"
+          include_tasks: search_available_network_subnet.yaml
           when: ip_route_result.stdout.find("via") == -1
       when: not ipv6_deployment|bool
     - name: IPv6 Validation
       block:
-        - name: Get IP route
+        - name: Get IPv6 route
           command: ip route get {{ he_ipv6_subnet_prefix + "::1" }}
           register: ip_route_result
         - debug: var=ip_route_result
         - name: Check if route exists
-          fail:
-            msg: >-
-              "Libvirt network subnet ({{ he_ipv6_subnet_prefix }}) is already in use."
-              "Please set it to an unused subnet by adding the variable 'he_ipv6_subnet_prefix'"
-              "to the variable-file. ( e.g. he_ipv6_subnet_prefix: 'fd00:9876:4321:900' )"
+          include_tasks: search_available_network_subnet.yaml
           when: ip_route_result.stdout.find("via") == -1
       when: ipv6_deployment|bool


### PR DESCRIPTION
If libvirt's network subnet is used, we search for
an available subnet to use instead.

It will insure that the local engine vm IP
will not collide with another machine's address

Bug-Url: https://bugzilla.redhat.com/1725033
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>