### PR TITLE
Pipe cat command to a shell command ended in 'grep'

### DIFF
--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -58,7 +58,7 @@
         when: he_appliance_ova is not none and he_appliance_ova|length > 0
       - debug: var=he_appliance_ova_path
       - name: Check available space on local VM directory
-        shell: df -k --output=avail "{{ he_local_vm_dir_path }}" | grep -v Avail
+        shell: df -k --output=avail "{{ he_local_vm_dir_path }}" | grep -v Avail | cat
         environment: "{{ he_cmd_lang }}"
         changed_when: true
         register: local_vm_dir_space_out

--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -286,7 +286,7 @@
       - debug: var=health_result
     rescue:
       - name: Check VM status at virt level
-        shell: virsh -r list | grep {{ he_vm_name }} | grep running
+        shell: virsh -r list | grep {{ he_vm_name }} | grep running | cat
         environment: "{{ he_cmd_lang }}"
         ignore_errors: true
         changed_when: true

--- a/tasks/fetch_host_ip.yml
+++ b/tasks/fetch_host_ip.yml
@@ -19,7 +19,7 @@
     - name: Choose IPv4, IPv6 or auto
       import_tasks: ipv_switch.yml
     - name: Get host address resolution
-      shell: getent {{ ip_key }} {{ he_host_address }} | grep STREAM
+      shell: getent {{ ip_key }} {{ he_host_address }} | grep STREAM | cat
       register: hostname_resolution_output
       changed_when: true
       ignore_errors: true

--- a/tasks/pre_checks/002_validate_hostname_tasks.yml
+++ b/tasks/pre_checks/002_validate_hostname_tasks.yml
@@ -84,7 +84,7 @@
           localhost is not a valid he_fqdn for the engine VM
       when: he_fqdn in ['localhost', 'localhost.localdomain']
     - name: Get engine FQDN resolution
-      shell: getent {{ ip_key }} {{ he_fqdn }} | grep STREAM
+      shell: getent {{ ip_key }} {{ he_fqdn }} | grep STREAM | cat
       environment: "{{ he_cmd_lang }}"
       register: fqdn_resolution_output
       changed_when: true


### PR DESCRIPTION
If a grep returned empty the 'shell' module fail.
To avoid that, adding '| cat' at the end of the command

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>