### PR TITLE
Enable fips mode on the bootstrap VM

### DIFF
--- a/tasks/apply_openscap_profile.yml
+++ b/tasks/apply_openscap_profile.yml
@@ -32,3 +32,17 @@
               regexp="^\s*PermitRootLogin"
               line="PermitRootLogin {{ he_root_ssh_access }}"
               state=present
+- name: Reboot the engine VM to ensure that FIPS is enabled
+  reboot:
+    reboot_timeout: 1200
+- block:
+    - name: Check if FIPS is enabled
+      command: sysctl -n crypto.fips_enabled
+      changed_when: true
+      register: he_fips_enabled
+    - debug: var=he_fips_enabled
+    - name: Enforce FIPS mode
+      fail:
+        msg: "FIPS mode is not enabled as required"
+      when: he_fips_enabled.stdout != "1"
+  when: ansible_distribution is search("RedHat")


### PR DESCRIPTION
Enable fips mode on the bootstrap engine VM
if needed.

Bug-Url: https://bugzilla.redhat.com/1734171
Fixes: https://bugzilla.redhat.com/1734171