### PR TITLE
Remove '| cat' from some tasks

### DIFF
--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -286,7 +286,7 @@
       - debug: var=health_result
     rescue:
       - name: Check VM status at virt level
-        shell: virsh -r list | grep {{ he_vm_name }} | grep running | cat
+        shell: virsh -r list | grep {{ he_vm_name }} | grep running
         environment: "{{ he_cmd_lang }}"
         ignore_errors: true
         changed_when: true

--- a/tasks/fetch_host_ip.yml
+++ b/tasks/fetch_host_ip.yml
@@ -19,7 +19,7 @@
     - name: Choose IPv4, IPv6 or auto
       import_tasks: ipv_switch.yml
     - name: Get host address resolution
-      shell: getent {{ ip_key }} {{ he_host_address }} | grep STREAM | cat
+      shell: getent {{ ip_key }} {{ he_host_address }} | grep STREAM
       register: hostname_resolution_output
       changed_when: true
       ignore_errors: true

--- a/tasks/pre_checks/002_validate_hostname_tasks.yml
+++ b/tasks/pre_checks/002_validate_hostname_tasks.yml
@@ -84,7 +84,7 @@
           localhost is not a valid he_fqdn for the engine VM
       when: he_fqdn in ['localhost', 'localhost.localdomain']
     - name: Get engine FQDN resolution
-      shell: getent {{ ip_key }} {{ he_fqdn }} | grep STREAM | cat
+      shell: getent {{ ip_key }} {{ he_fqdn }} | grep STREAM
       environment: "{{ he_cmd_lang }}"
       register: fqdn_resolution_output
       changed_when: true


### PR DESCRIPTION
'| cat' was previously added to prevent command tasks
to fail if 'grep' returns empty.
In some places in the Role the failure of these tasks,
is a part of the logic and handled with 'ignore_errors: true'.
Thus, Removing the '| cat' from them for keep the logic correct.

Bug-Url: https://bugzilla.redhat.com/1737353
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>