### PR TITLE
Add LANGUAGE env variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 # Changes in this section are NOT supported
 
 he_cmd_lang:
+  LANGUAGE: en_US.UTF-8
   LANG: en_US.UTF-8
   LC_MESSAGES: en_US.UTF-8
   LC_ALL: en_US.UTF-8


### PR DESCRIPTION
GNU gettext gives preference to LANGUAGE over LC_ALL and LANG.
Thus, set the variable to en_US.UTF-8 to ensure an English
output, if it is set to other locale.

more info can be found here:
https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html#Locale-Environment-Variables

Bug-Url: https://bugzilla.redhat.com/1711672
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>