### PR TITLE
Add VM with VM lease

### DIFF
--- a/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
+++ b/tasks/create_target_vm/01_create_target_hosted_engine_vm.yml
@@ -199,8 +199,10 @@
       serial_console: false
       operating_system: rhel_7x64
       type: server
+      high_availability: 'yes'
       high_availability_priority: 1
       delete_protected: true
+      lease: "{{ he_storage_domain_name }}"
       # timezone: "{{ he_time_zone }}" # TODO: fix with the right parameter syntax
       disks:
         - id: "{{ he_virtio_disk_details.disk.id }}"


### PR DESCRIPTION
Currently the hosted engine VM is added with a
volume lease (which is injected by the engine).

VM leases are available since 4.1 and this the
start of trying to use VM lease instead more can
be found on [1][2].

This requires a change to the engine as well to
prevent injecting the volume lease [3].

This patch is not working currently and is pushed
mostly for discussion purposes.

[1]https://bugzilla.redhat.com/show_bug.cgi?id=1719582
[2]https://bugzilla.redhat.com/show_bug.cgi?id=1670788
[3]https://gerrit.ovirt.org/#/c/102452/

Signed-off-by: Gal Zaidman <gzaidman@redhat.com>