### PR TITLE
Remove libvirt default network leftover

### DIFF
--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -106,6 +106,17 @@
       name: "{{ he_vm_name }}Local"
       command: undefine
       uri: 'qemu+tls://{{ he_host_address }}/system'
+  - name: Update libvirt default network configuration, destroy
+    virt_net:
+      command: destroy
+      name: default
+      uri: 'qemu+tls://{{ he_host_address }}/system'
+  - name: Update libvirt default network configuration, undefine
+    virt_net:
+      command: undefine
+      name: default
+      uri: 'qemu+tls://{{ he_host_address }}/system'
+    ignore_errors: true
   - name: Detect ovirt-hosted-engine-ha version
     command: >-
       python -c 'from ovirt_hosted_engine_ha.agent import constants as agentconst; print(agentconst.PACKAGE_VERSION)'


### PR DESCRIPTION
Remove libvirt default network that was temorarely used
for bootstrap vm.