### PR TITLE
network: dns: add an entry for the engine VM under /etc/hosts

### DIFF
--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -225,6 +225,12 @@
       dest: "{{ he_local_vm_dir }}/hosts"
       regexp: "# hosted-engine-setup-{{ hostvars[he_ansible_host_name]['he_local_vm_dir'] }}$"
       state: absent
+  - name: Add an entry on /etc/hosts for the Hosted Engine VM for the VM itself
+    lineinfile:
+      dest: "{{ he_local_vm_dir }}/hosts"
+      line: "{{ he_vm_ip_addr }} {{ he_fqdn }}"
+      state: present
+    when: he_vm_etc_hosts and he_vm_ip_addr is not none
   - name: Clean /etc/hosts for the Hosted Engine VM for host address
     lineinfile:
       dest: "{{ he_local_vm_dir }}/hosts"


### PR DESCRIPTION
If both he_vm_etc_hosts and he_vm_ip_addr are set,
add an entry in /etc/hosts for the target VM itself.
This could be especially useful on dual stack
environments to override system DNS resolution.