### PR TITLE
Drop 4.2 pipeline

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -3,4 +3,4 @@ distros:
   - fc29
   - el7
 release_branches:
-  master: ["ovirt-master", "ovirt-4.3", "ovirt-4.2"]
+  master: ["ovirt-master", "ovirt-4.3"]


### PR DESCRIPTION
Drop 4.2 pipeline following CI infra request at
https://lists.ovirt.org/archives/list/infra@ovirt.org/thread/4SKBLVF7AFCAKWM6ZBB6BLDY6B3TDSTP/