### PR TITLE
 Don't skip volume creation when using qemu-img convert

### DIFF
--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -250,7 +250,7 @@
       LC_ALL: en_US.UTF-8
     changed_when: true
   - name: Copy local VM disk to shared storage
-    command: qemu-img convert -n -O raw {{ local_vm_disk_path }} {{ he_virtio_disk_path }}
+    command: qemu-img convert -O raw {{ local_vm_disk_path }} {{ he_virtio_disk_path }}
     environment: "{{ he_cmd_lang }}"
     become: true
     become_user: vdsm


### PR DESCRIPTION
Removing -n option fixes hosted-engine installation failure
in ost using CentOS8

Signed-off-by: Asaf Rachmani <arachman@redhat.com>