### PR TITLE
tasks: pre_checks: Fix interface name issue that contains dash char

### DIFF
--- a/tasks/pre_checks/001_validate_network_interfaces.yml
+++ b/tasks/pre_checks/001_validate_network_interfaces.yml
@@ -15,7 +15,7 @@
     vars:
       acceptable_bond_modes: ['active-backup', 'balance-xor', 'broadcast', '802.3ad']
     set_fact:
-      otopi_net_host="{{ iface_item }}"
+      otopi_net_host="{{ hostvars[inventory_hostname]['ansible_' + iface_item]['device'] }}"
       type="{{ hostvars[inventory_hostname]['ansible_' + iface_item]['type'] }}"
       bond_valid_name="{{ iface_item | regex_search('(^bond[0-9]+)') }}"
     when: (
@@ -67,7 +67,7 @@
     set_fact:
       otopi_host_net: >-
         {{ [bridge_interface] if bridge_interface is defined else bb_filtered_list.results |
-        reject('skipped') | map(attribute='bond_item.iface_item') | list }}
+        reject('skipped') | map(attribute='bond_item.ansible_facts.otopi_net_host') | list }}
     register: otopi_host_net
   - debug: var=otopi_host_net
   - name: Validate selected bridge interface if management bridge does not exist


### PR DESCRIPTION
In order to get interface details from Ansible facts,
if the interface name contains a dash it's replaced with an underscore.
This led to "device does not exist" error when the interface name
was not converted back to the original one containing a dash.

Bug-Url: https://bugzilla.redhat.com/1459229
Signed-off-by: Asaf Rachmani <arachman@redhat.com>