### PR TITLE
Honor ovirt_engine_setup_update_all_packages if explicitly set

### DIFF
--- a/tasks/full_execution.yml
+++ b/tasks/full_execution.yml
@@ -35,7 +35,7 @@
         ovirt_engine_setup_firewall_manager: null
         ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
         ovirt_engine_setup_use_remote_answer_file: true
-        ovirt_engine_setup_update_all_packages: false
+        ovirt_engine_setup_update_all_packages: "{{ ovirt_engine_setup_update_all_packages | default(false) }}"
         ovirt_engine_setup_offline: true
         ovirt_engine_setup_admin_password: "{{ he_admin_password }}"
       import_role:

--- a/tasks/partial_execution.yml
+++ b/tasks/partial_execution.yml
@@ -53,7 +53,7 @@
         ovirt_engine_setup_firewall_manager: null
         ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
         ovirt_engine_setup_use_remote_answer_file: true
-        ovirt_engine_setup_update_all_packages: false
+        ovirt_engine_setup_update_all_packages: "{{ ovirt_engine_setup_update_all_packages | default(false) }}"
         ovirt_engine_setup_offline: true
         ovirt_engine_setup_admin_password: "{{ he_admin_password }}"
       import_role:


### PR DESCRIPTION
Honor ovirt_engine_setup_update_all_packages
if explicitly set, if not keep false as the default
to maintaing previous behavior while the devault value
in ovirt-ansible-engine-setup is instead true.

Fixes: #280