### PR TITLE
tasks: pre_check: Filter teaming devices

### DIFF
--- a/tasks/filter_team_devices.yml
+++ b/tasks/filter_team_devices.yml
@@ -1,0 +1,35 @@
+---
+- name: Collect interface types
+  shell: set -euo pipefail && nmcli con show {{ nic }} | grep connection.type
+  with_items:
+    - "{{ host_net }}"
+  loop_control:
+    loop_var: nic
+  changed_when: true
+  register: interface_types
+- debug: var=interface_types
+- name: Check for Team devices
+  set_fact:
+    is_team: "{{ nic_if.stdout.find('team') > 0 }}"
+  when: nic_if.stdout.find('team') != -1
+  with_items:
+    - "{{ interface_types.results }}"
+  loop_control:
+    loop_var: nic_if
+  register: team_list
+- debug: var=team_list
+- name: Get list of Team devices
+  set_fact:
+    team_if: "{{  team_list.results | reject('skipped') | map(attribute='nic_if.nic') | list }}"
+- debug: var=team_if
+- name: Filter unsupported interface types
+  set_fact:
+    otopi_host_net: "{{ host_net | difference(team_if) }}"
+  register: otopi_host_net
+- debug: var=otopi_host_net
+- name: Failed if only teaming devices are availible
+  fail:
+    msg: >-
+      Only Team devices {{ team_if | join(', ') }} are present.
+      Teaming is not supported.
+  when: (otopi_host_net | length == 0)

--- a/tasks/pre_checks/001_validate_network_interfaces.yml
+++ b/tasks/pre_checks/001_validate_network_interfaces.yml
@@ -65,11 +65,12 @@
   - debug: var=bb_filtered_list
   - name: Generate output list
     set_fact:
-      otopi_host_net: >-
+      host_net: >-
         {{ [bridge_interface] if bridge_interface is defined else bb_filtered_list.results |
         reject('skipped') | map(attribute='bond_item.ansible_facts.otopi_net_host') | list }}
-    register: otopi_host_net
-  - debug: var=otopi_host_net
+    register: host_net
+  - debug: var=host_net
+  - import_tasks: filter_team_devices.yml
   - name: Validate selected bridge interface if management bridge does not exist
     fail:
       msg: The selected network interface is not valid


### PR DESCRIPTION
Failed with a clear error message when only teaming devices
are available

Bug-Url: https://bugzilla.redhat.com/1602816
Signed-off-by: Asaf Rachmani <arachman@redhat.com>