### PR TITLE
tasks: filter_team_devices: Use device instead of connection name

### DIFF
--- a/tasks/filter_team_devices.yml
+++ b/tasks/filter_team_devices.yml
@@ -1,6 +1,6 @@
 ---
 - name: Collect interface types
-  shell: set -euo pipefail && nmcli con show {{ nic }} | grep connection.type
+  shell: set -euo pipefail && nmcli -g GENERAL.TYPE device show {{ nic }}
   with_items:
     - "{{ host_net }}"
   loop_control:


### PR DESCRIPTION
Signed-off-by: Asaf Rachmani <arachman@redhat.com>