### PR TITLE
bump to 1.1.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.0.36"
+VERSION="1.1.0"
 MILESTONE=
 RPM_RELEASE="1"
 


### PR DESCRIPTION
in case we need updates for 4.3 we need 1.0.z to be available for
building fixes. Using 1.1.z fro master / 4.4