### PR TITLE
configure engine VM to start with consistent interface name: eth0

### DIFF
--- a/tasks/bootstrap_local_vm/02_create_local_vm.yml
+++ b/tasks/bootstrap_local_vm/02_create_local_vm.yml
@@ -105,12 +105,12 @@
         with_items:
           - {src: templates/user-data.j2, dest: "{{ he_local_vm_dir }}/user-data"}
           - {src: templates/meta-data.j2, dest: "{{ he_local_vm_dir }}/meta-data"}
-          - {src: templates/network-config-dhcp6.j2, dest: "{{ he_local_vm_dir }}/network-config"}
+          - {src: templates/network-config-dhcp.j2, dest: "{{ he_local_vm_dir }}/network-config"}
       - name: Create ISO disk
         command: >-
           mkisofs -output {{ he_local_vm_dir }}/seed.iso -volid cidata -joliet -rock -input-charset utf-8
           {{ he_local_vm_dir }}/meta-data {{ he_local_vm_dir }}/user-data
-          {{ he_local_vm_dir + '/network-config' if ipv6_deployment else None }}
+          {{ he_local_vm_dir }}/network-config
         environment: "{{ he_cmd_lang }}"
         changed_when: true
       - name: Create local VM

--- a/templates/network-config-dhcp.j2
+++ b/templates/network-config-dhcp.j2
@@ -4,4 +4,8 @@ config:
     name: eth0
     mac_address: {{ he_vm_mac_addr }}
     subnets:
+{% if ipv6_deployment %}
       - type: dhcp6
+{% else %}
+      - type: dhcp
+{% endif %}


### PR DESCRIPTION
in  EL8 engine VM interface name is not consistent.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1807060
Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>