### PR TITLE
Avoid link local as host IP address

### DIFF
--- a/tasks/fetch_host_ip.yml
+++ b/tasks/fetch_host_ip.yml
@@ -31,7 +31,14 @@
       when: hostname_resolution_output.rc != 0
     - name: Parse host address resolution
       set_fact:
-        he_host_ip: "{{ hostname_resolution_output.stdout.split()[0] }}"
+        he_host_ip: "{{
+        (
+          hostname_resolution_output.stdout.split() | ipaddr |
+            difference(hostname_resolution_output.stdout.split() |
+              ipaddr('link-local')
+            )
+        )[0]
+        }}"
     - debug: var=he_host_ip
 
 - name: Fail if host's ip is empty


### PR DESCRIPTION
The host IP address is set to the first IP address the fqdn
resolves, which is no link local address.
It might happen that the hostname is resolved to a link local
address, but hosted engine is usually expected not to use a
link local address.

Bug-Url: https://bugzilla.redhat.com/1756244

@eslutsky @didib Can you please have a look?
I will do a full verification, if we agree on the basic approach.