### PR TITLE
Use he_offline_deployment if explicitly set

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ No.
 | he_tcp_t_address | null | hostname to connect if he_network_test is *tcp*  |
 | he_tcp_t_port | null | port to connect if he_network_test is *tcp* |
 | he_pause_host | false | Pause the execution to let the user interactively fix host configuration |
+| he_offline_deployment | false | If `True`, updates for all packages will be disabled |
 
 ## NFS / Gluster Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,6 +100,7 @@ he_tcp_t_port: null
 # ovirt-hosted-engine-setup variables
 he_just_collect_network_interfaces: false
 he_libvirt_authfile: '/etc/ovirt-hosted-engine/virsh_auth.conf'
+he_offline_deployment: false
 
 # *** Do Not Use On Production Environment ***
 # ********** Used for testing ONLY ***********

--- a/tasks/full_execution.yml
+++ b/tasks/full_execution.yml
@@ -35,8 +35,7 @@
         ovirt_engine_setup_firewall_manager: null
         ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
         ovirt_engine_setup_use_remote_answer_file: true
-        ovirt_engine_setup_update_all_packages: false
-        ovirt_engine_setup_offline: true
+        ovirt_engine_setup_offline: "{{ he_offline_deployment }}"
         ovirt_engine_setup_admin_password: "{{ he_admin_password }}"
       import_role:
         name: ovirt.engine-setup

--- a/tasks/partial_execution.yml
+++ b/tasks/partial_execution.yml
@@ -53,8 +53,7 @@
         ovirt_engine_setup_firewall_manager: null
         ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
         ovirt_engine_setup_use_remote_answer_file: true
-        ovirt_engine_setup_update_all_packages: false
-        ovirt_engine_setup_offline: true
+        ovirt_engine_setup_offline: "{{ he_offline_deployment }}"
         ovirt_engine_setup_admin_password: "{{ he_admin_password }}"
       import_role:
         name: ovirt.engine-setup


### PR DESCRIPTION
- Use he_offline_deployment parameter if explicitly set
- Use only ovirt_engine_setup_offline parameter for update packages
- Change the default value of ovirt_engine_setup_offline to false in order to 
   update packages
- Remove ovirt_engine_setup_update_all_packages parameter
- Update README

Bug-Url: https://bugzilla.redhat.com/1816619
Signed-off-by: Asaf Rachmani <arachman@redhat.com>