### PR TITLE
Add support for custom cpu_type for cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ No.
 | he_restore_from_file | null | a backup file created with engine-backup to be restored on the fly |
 | he_pki_renew_on_restore | false | Renew engine PKI on restore if needed |
 | he_cluster | Default | name of the cluster with hosted-engine hosts |
-| he_cluster_cpu_type | null | cluster CPU type to be used in hosted-engine cluster (the same as he host or lower) |
+| he_cluster_cpu_type | null | cluster CPU type to be used in hosted-engine cluster (the same as HE host or lower) |
 | he_data_center | Default | name of the datacenter with hosted-engine hosts |
 | he_host_name | $(hostname -f) | name used by the engine for the first host |
 | he_host_address | $(hostname -f) | address used by the engine for the first host |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ No.
 | he_restore_from_file | null | a backup file created with engine-backup to be restored on the fly |
 | he_pki_renew_on_restore | false | Renew engine PKI on restore if needed |
 | he_cluster | Default | name of the cluster with hosted-engine hosts |
+| he_cluster_cpu_type | null | cluster CPU type to be used in hosted-engine cluster (the same as he host or lower) |
 | he_data_center | Default | name of the datacenter with hosted-engine hosts |
 | he_host_name | $(hostname -f) | name used by the engine for the first host |
 | he_host_address | $(hostname -f) | address used by the engine for the first host |

--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -59,7 +59,7 @@
       state: present
       name: "{{ he_cluster }}"
       data_center: "{{ he_data_center }}"
-      cpu_type:  "{{ he_cluster_cpu_type | default(omit) }}"
+      cpu_type: "{{ he_cluster_cpu_type | default(omit) }}"
       wait: true
       auth: "{{ ovirt_auth }}"
     register: cluster_result_presence

--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -59,6 +59,7 @@
       state: present
       name: "{{ he_cluster }}"
       data_center: "{{ he_data_center }}"
+      cpu_type:  "{{ he_cluster_cpu_type | default(omit) }}"
       wait: true
       auth: "{{ ovirt_auth }}"
     register: cluster_result_presence


### PR DESCRIPTION
Required by QE automation
Allow to specify CPU type to be used ofr the hosted engine cluster.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1820146