### PR TITLE
remove version lock from the engine

### DIFF
--- a/tasks/restore_backup.yml
+++ b/tasks/restore_backup.yml
@@ -97,3 +97,11 @@
   with_items:
     - "OVESETUP_PKI/renew=bool:{{ he_pki_renew_on_restore }}"
     - "QUESTION/1/OVESETUP_SKIP_RENEW_PKI_CONFIRM=str:yes"
+- name: remove version lock from the engine
+  file:
+    state: absent
+    path: /etc/yum/pluginconf.d/versionlock.list
+- name: recreate versionlock empty file
+  file:
+    state: touch
+    path: /etc/yum/pluginconf.d/versionlock.list


### PR DESCRIPTION
the patch removes the yam version lock , after the engine recovery and before the engine-setup role execution.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1827135
Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>