### PR TITLE
storage: Verify copy of VM disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ No.
 | he_pause_host | false | Pause the execution to let the user interactively fix host configuration |
 | he_offline_deployment | false | If `True`, updates for all packages will be disabled |
 | he_additional_package_list | [] | List of additional packages to be installed on engine VM apart from ovirt-engine package |
+| he_debug_mode | false | If `True`, HE deployment will execute additional tasks for debug |
 
 ## NFS / Gluster Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ he_force_ip4: false
 he_force_ip6: false
 
 he_pause_host: false
+he_debug_mode: false
 
 ## Mandatory variables:
 

--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -248,6 +248,14 @@
     become_user: vdsm
     become_method: sudo
     changed_when: true
+  - name: Verify copy of VM disk
+    command: qemu-img compare {{ local_vm_disk_path }} {{ he_virtio_disk_path }}
+    environment: "{{ he_cmd_lang }}"
+    become: true
+    become_user: vdsm
+    become_method: sudo
+    changed_when: true
+    when: he_debug_mode|bool
   - name: Remove temporary entry in /etc/hosts for the local VM
     lineinfile:
       dest: /etc/hosts


### PR DESCRIPTION
- Add he_debug_mode variable to execute debug tasks
- Add a task in debug mode that verifies copying of VM disk
  by comparing local VM image with shared storage image
- Update README

Bug-Url: https://bugzilla.redhat.com/1828892
Signed-off-by: Asaf Rachmani <arachman@redhat.com>