### PR TITLE
Call 'sync' before fetching engine logs

### DIFF
--- a/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
+++ b/tasks/bootstrap_local_vm/03_engine_initial_tasks.yml
@@ -50,6 +50,9 @@
       - include_tasks: restore_backup.yml
     when: he_restore_from_file is defined and he_restore_from_file
   rescue:
+    - name: Sync on engine machine
+      command: sync
+      changed_when: true
     - name: Fetch logs from the engine VM
       import_tasks: fetch_engine_logs.yml
       ignore_errors: true

--- a/tasks/bootstrap_local_vm/04_engine_final_tasks.yml
+++ b/tasks/bootstrap_local_vm/04_engine_final_tasks.yml
@@ -52,6 +52,9 @@
       - cloud-init-local
       - cloud-init
   rescue:
+    - name: Sync on engine machine
+      command: sync
+      changed_when: true
     - name: Fetch logs from the engine VM
       import_tasks: fetch_engine_logs.yml
       ignore_errors: true

--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -188,6 +188,9 @@
       host_result_up_check.ovirt_hosts|length >= 1 and
       host_result_up_check.ovirt_hosts[0].status == 'non_operational'
   rescue:
+    - name: Sync on engine machine
+      command: sync
+      changed_when: true
     - name: Fetch logs from the engine VM
       include_tasks: fetch_engine_logs.yml
       ignore_errors: true

--- a/tasks/full_execution.yml
+++ b/tasks/full_execution.yml
@@ -65,5 +65,9 @@
   block:
     - name: Hosted engine final tasks
       import_tasks: create_target_vm/03_hosted_engine_final_tasks.yml
+    - name: Sync on engine machine
+      command: sync
+      changed_when: true
+      delegate_to: "{{ groups.engine[0] }}"
     - name: Final clean
       import_tasks: final_clean.yml


### PR DESCRIPTION
Sometimes, on failed deploy attempts, engine-logs* directories are
created but left empty. I am guessing that this might be because the
files there are still cached in memory, and we do not fetch from the
engine vm itself (using e.g. ssh) but from the host, directly accessing
the vm disk image. So if, before that, we run 'sync' on the engine vm,
we have better chances to successfully get the logs from the image.