### PR TITLE
Don't retry if SSO fails after moving the HE VM to shared storage

### DIFF
--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -365,23 +365,12 @@
   # Workaround for https://bugzilla.redhat.com/1540107
   # the engine fails deleting a VM if its status in the engine DB
   # is not up to date.
-  - name: Identify the bootstrap local VM
-    block:
-      - include_tasks: auth_sso.yml
-      - name: Check for the local bootstrap VM
-        ovirt_vm_facts:
-          pattern: id="{{ external_local_vm_uuid.stdout_lines|first }}"
-          auth: "{{ ovirt_auth }}"
-        register: local_vm_f
-    rescue:
-      # let's simply try a second time with a fresh token
-      # as a workaround for https://bugzilla.redhat.com/1660595
-      - include_tasks: auth_sso.yml
-      - name: Check for the local bootstrap VM
-        ovirt_vm_facts:
-          pattern: id="{{ external_local_vm_uuid.stdout_lines|first }}"
-          auth: "{{ ovirt_auth }}"
-        register: local_vm_f
+  - include_tasks: auth_sso.yml
+  - name: Check for the local bootstrap VM
+    ovirt_vm_facts:
+      pattern: id="{{ external_local_vm_uuid.stdout_lines|first }}"
+      auth: "{{ ovirt_auth }}"
+    register: local_vm_f
   - name: Remove the bootstrap local VM
     block:
       - name: Make the engine aware that the external VM is stopped


### PR DESCRIPTION
The commit 3439d2dd2fc63efae94c5efca87d56934cad6637 was created as per the
RHBZ 1660595 where the root cause of the issue was because of DNS
resolution. Also, there was a follow up bug RHBZ 1716077 which also concluded
the root cause of the issue is because of the DNS issue and I was
also having a customer issue where also the issue was because of DNS
resolution. Retry will not help in any of these cases.
    
There is no evidence that this issue can happen because of a race condition
in engine.
