### PR TITLE
Stop and disable libvirtd-tls.socket in intial clean

### DIFF
--- a/tasks/initial_clean.yml
+++ b/tasks/initial_clean.yml
@@ -63,6 +63,7 @@
       - ovirt-ha-agent
       - ovirt-ha-broker
       - vdsmd
+      - libvirtd-tls.socket
   - name: Restore initial libvirt default network configuration
     copy:
       remote_src: true


### PR DESCRIPTION
If the libvirtd-tls.socket service is not disabled, then the libvirtd will fail to start with error "Cannot read certificate '/etc/pki/libvirt/servercert.pem': No such file or directory." if we reattempt after a failed deployment. 

The libvirtd will check for the certificates if the tls socket service is enabled and fails with the mentioned error. This issue happens if we reattempt the deployment when it fails after the libvirtd was configured for the vdsm. 