### PR TITLE
Allow update packages in 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ No.
 | he_tcp_t_address | null | hostname to connect if he_network_test is *tcp*  |
 | he_tcp_t_port | null | port to connect if he_network_test is *tcp* |
 | he_pause_host | false | Pause the execution to let the user interactively fix host configuration |
+| he_offline_deployment | false | If `True`, updates for all packages will be disabled |
+| he_additional_package_list | [] | List of additional packages to be installed on engine VM apart from ovirt-engine package |
 
 ## NFS / Gluster Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,6 +100,8 @@ he_tcp_t_port: null
 # ovirt-hosted-engine-setup variables
 he_just_collect_network_interfaces: false
 he_libvirt_authfile: '/etc/ovirt-hosted-engine/virsh_auth.conf'
+he_offline_deployment: false
+he_additional_package_list: []
 
 # *** Do Not Use On Production Environment ***
 # ********** Used for testing ONLY ***********

--- a/tasks/full_execution.yml
+++ b/tasks/full_execution.yml
@@ -36,7 +36,7 @@
         ovirt_engine_setup_answer_file_path: /root/ovirt-engine-answers
         ovirt_engine_setup_use_remote_answer_file: true
         ovirt_engine_setup_update_all_packages: false
-        ovirt_engine_setup_offline: true
+        ovirt_engine_setup_offline: "{{ he_offline_deployment }}"
         ovirt_engine_setup_admin_password: "{{ he_admin_password }}"
       import_role:
         name: ovirt.engine-setup

--- a/tasks/full_execution.yml
+++ b/tasks/full_execution.yml
@@ -37,6 +37,7 @@
         ovirt_engine_setup_use_remote_answer_file: true
         ovirt_engine_setup_update_all_packages: false
         ovirt_engine_setup_offline: "{{ he_offline_deployment }}"
+        ovirt_engine_setup_package_list: "{{ he_additional_package_list }}"
         ovirt_engine_setup_admin_password: "{{ he_admin_password }}"
       import_role:
         name: ovirt.engine-setup


### PR DESCRIPTION
Since the last change we are missing the update of all packages before engine_setup.