### PR TITLE
WIP: Check OVF_STORE volume status: Try 20 minutes

### DIFF
--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -33,7 +33,7 @@
     environment: "{{ he_cmd_lang }}"
     changed_when: true
     register: ovf_store_status
-    retries: 12
+    retries: 120
     delay: 10
     until: >-
       ovf_store_status.rc == 0 and ovf_store_status.stdout|from_json|json_query('status') == 'OK' and


### PR DESCRIPTION
Try 120 times instead of 12 (with 10 seconds delay in between).

hosted-engine deploy fails for some time now in CI at this point, I
wonder if this is simply because the engine needs more time for some
reason to update OVF_STORE.