### PR TITLE
wait for wakeup networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ No.
 | he_mount_options | '' | NFS mount options
 | he_storage_domain_path | null | shared folder path on NFS server |
 | he_nfs_version | auto | NFS version.  available options: *auto*, *v4*, *v3*, *v4_0*, *v4_1*, *v4_2*
+| he_storage_if | null | the network interface name that is connected to the storage network, assumed to be pre-configured|
 
 
 ## ISCSI Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,6 +73,7 @@ he_storage_domain_addr: null
 he_mount_options: ''
 he_storage_domain_path: null
 he_nfs_version: auto  # can be: auto, v4 or v3
+he_storage_if: null
 
 ## ISCSI vars:
 ## Defaults are null, user should specify if ISCSI is chosen

--- a/tasks/create_storage_domain.yml
+++ b/tasks/create_storage_domain.yml
@@ -1,6 +1,15 @@
 ---
 - name: Create hosted engine local vm
   block:
+  - name: Wait for the storage interface to be up
+    command: ip -j link show '{{ he_storage_if }}'
+    register: storage_if_result_up_check
+    until: >-
+      storage_if_result_up_check.stdout|from_json|map(attribute='operstate')|join('') == 'UP'
+    retries: 120
+    delay: 5
+    delegate_to: "{{ he_ansible_host_name }}"
+    when: (he_domain_type == "glusterfs" or he_domain_type == "nfs") and he_storage_if is not none
   - name: Check local VM dir stat
     stat:
       path: "{{ he_local_vm_dir }}"


### PR DESCRIPTION
If several tagged networks are connected to the Bond interface - for example, a management network and a dedicated network for NFS or GlusterFS storage. In this case, networks with tags other than management do not have enough time to wake up after reconfiguring the host networks. The role checks through the management network whether the host is running. As a result, the task of connecting the storage fails