### PR TITLE
[RFR]Fix firewalld to allow health check to complete

### DIFF
--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -4,13 +4,13 @@
   - name: Open a port on firewalld
     firewalld:
       service: "{{ item }}"
-      permanent: false
+      permanent: true
       immediate: true
       state: enabled
-    delegate_to: "{{ he_fqdn }}" 
+    delegate_to: "{{ he_fqdn }}"
     loop:
-      - http
-      - https
+      - ovirt-http
+      - ovirt-https
   - name: Wait for ovirt-engine service to start
     uri:
       url: http://{{ he_fqdn }}/ovirt-engine/services/health

--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -1,6 +1,16 @@
 ---
 - name: Add host
   block:
+  - name: Open a port on firewalld
+    firewalld:
+      service: "{{ item }}"
+      permanent: false
+      immediate: true
+      state: enabled
+    delegate_to: "{{ he_fqdn }}" 
+    loop:
+      - http
+      - https
   - name: Wait for ovirt-engine service to start
     uri:
       url: http://{{ he_fqdn }}/ovirt-engine/services/health

--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -311,16 +311,6 @@
   - debug: var=mresult
   - name: Wait for the engine to come up on the target VM
     block:
-      - name: Make sure http/https is open in firewalld on Engine VM
-        firewalld:
-          service: "{{ item }}"
-          permanent: false
-          immediate: true
-          state: enabled
-        delegate_to: "{{ he_fqdn }}"
-        loop:
-          - http
-          - https
       - name: Check engine VM health
         command: hosted-engine --vm-status --json
         environment: "{{ he_cmd_lang }}"

--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -311,6 +311,16 @@
   - debug: var=mresult
   - name: Wait for the engine to come up on the target VM
     block:
+      - name: Make sure http/https is open in firewalld on Engine VM
+        firewalld:
+          service: "{{ item }}"
+          permanent: false
+          immediate: true
+          state: enabled
+        delegate_to: "{{ he_fqdn }}"
+        loop:
+          - http
+          - https
       - name: Check engine VM health
         command: hosted-engine --vm-status --json
         environment: "{{ he_cmd_lang }}"


### PR DESCRIPTION
# Problem

With latest RHV 4.4.1 I am not able to successfully utilize this role for hosted engine setup. It fails in file `tasks/bootstrap_local_vm/05_add_host.yml` on task `  - name: Wait for ovirt-engine service to start`. I found out that firewalld on hosted engine VM was not allowing http/https connections during setup. 

# Solution

Adding firewalld https/http services to enable the communication between RHV host and Engine VM. I have tested this multiple times and it works consistently.