### PR TITLE
Set file permissions

### DIFF
--- a/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
+++ b/tasks/create_target_vm/03_hosted_engine_final_tasks.yml
@@ -123,6 +123,7 @@
     template:
       src: "{{ item.src }}"
       dest: "{{ item.dest }}"
+      mode: 0644
     with_items:
       - {src: templates/vm.conf.j2, dest: "{{ he_local_vm_dir }}/vm.conf"}
       - {src: templates/broker.conf.j2, dest: "{{ he_local_vm_dir }}/broker.conf"}
@@ -148,6 +149,7 @@
       remote_src: true
       src: "{{ item.src }}"
       dest: "{{ item.dest }}"
+      mode: 0644
     with_items:
       - {src: "{{ he_local_vm_dir }}/vm.conf", dest: /var/run/ovirt-hosted-engine-ha}
       - {src: "{{ he_local_vm_dir }}/hosted-engine.conf", dest: /etc/ovirt-hosted-engine/}


### PR DESCRIPTION
Ansible changed the default file permissions to 600.
Adding `mode` to set the correct file permissions.

Bug-Url: https://bugzilla.redhat.com/1871854
Signed-off-by: Asaf Rachmani <arachman@redhat.com>