### PR TITLE
Set hosted-engine VM with custom bios type (Q35+SeaBIOS)

### DIFF
--- a/tasks/create_target_vm/02_engine_vm_configuration.yml
+++ b/tasks/create_target_vm/02_engine_vm_configuration.yml
@@ -21,6 +21,10 @@
     register: db_vm_update
     with_items:
       - {field: 'origin', value: 6}
+      # The following is a workaround for setting custom bios type for the hosted-engine VM to prevent
+      # its bios type from changing when the cluster's bios type changes. This should be replaced in
+      # later version with a proper setting of the bios type once we use ovirt-ansible-collection
+      - {field: 'bios_type', value: 2}
   - debug: var=db_vm_update
   - name: Insert Hosted Engine configuration disk uuid into Engine database
     command: >-


### PR DESCRIPTION
To prevent its chipset/firmware from changing when the corresponding
cluster setting is changed.

Signed-off-by: Arik Hadas <ahadas@redhat.com>