### PR TITLE
add compatibility version for hosted engine dc and cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ No.
 | he_cluster | Default | name of the cluster with hosted-engine hosts |
 | he_cluster_cpu_type | null | cluster CPU type to be used in hosted-engine cluster (the same as HE host or lower) |
 | he_data_center | Default | name of the datacenter with hosted-engine hosts |
+| he_compatibility_version | null | Compatibility version of the hosted-engine data center and cluster. Default value is the latest compatibility version |
 | he_host_name | $(hostname -f) | name used by the engine for the first host |
 | he_host_address | $(hostname -f) | address used by the engine for the first host |
 | he_bridge_if | null | interface used for the management bridge |

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ No.
 | he_pki_renew_on_restore | false | Renew engine PKI on restore if needed |
 | he_cluster | Default | name of the cluster with hosted-engine hosts |
 | he_cluster_cpu_type | null | cluster CPU type to be used in hosted-engine cluster (the same as HE host or lower) |
+| he_cluster_comp_version | null | Compatibility version of the hosted-engine cluster. Default value is the latest compatibility version |
 | he_data_center | Default | name of the datacenter with hosted-engine hosts |
-| he_compatibility_version | null | Compatibility version of the hosted-engine data center and cluster. Default value is the latest compatibility version |
+| he_data_center_comp_version | null | Compatibility version of the hosted-engine data center. Default value is the latest compatibility version |
 | he_host_name | $(hostname -f) | name used by the engine for the first host |
 | he_host_address | $(hostname -f) | address used by the engine for the first host |
 | he_bridge_if | null | interface used for the management bridge |

--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -50,6 +50,7 @@
     ovirt_datacenter:
       state: present
       name: "{{ he_data_center }}"
+      compatibility_version: "{{ he_compatibility_version | default(omit) }}"
       wait: true
       local: false
       auth: "{{ ovirt_auth }}"
@@ -58,6 +59,7 @@
     ovirt_cluster:
       state: present
       name: "{{ he_cluster }}"
+      compatibility_version: "{{ he_compatibility_version | default(omit) }}"
       data_center: "{{ he_data_center }}"
       cpu_type: "{{ he_cluster_cpu_type | default(omit) }}"
       wait: true
@@ -75,6 +77,7 @@
     ovirt_cluster:
       data_center: "{{ he_data_center }}"
       name: "{{ he_cluster }}"
+      compatibility_version: "{{ he_compatibility_version | default(omit) }}"
       auth: "{{ ovirt_auth }}"
       virt: true
       gluster: true

--- a/tasks/bootstrap_local_vm/05_add_host.yml
+++ b/tasks/bootstrap_local_vm/05_add_host.yml
@@ -50,7 +50,7 @@
     ovirt_datacenter:
       state: present
       name: "{{ he_data_center }}"
-      compatibility_version: "{{ he_compatibility_version | default(omit) }}"
+      compatibility_version: "{{ he_data_center_comp_version | default(omit) }}"
       wait: true
       local: false
       auth: "{{ ovirt_auth }}"
@@ -59,7 +59,7 @@
     ovirt_cluster:
       state: present
       name: "{{ he_cluster }}"
-      compatibility_version: "{{ he_compatibility_version | default(omit) }}"
+      compatibility_version: "{{ he_cluster_comp_version | default(omit) }}"
       data_center: "{{ he_data_center }}"
       cpu_type: "{{ he_cluster_cpu_type | default(omit) }}"
       wait: true
@@ -77,7 +77,7 @@
     ovirt_cluster:
       data_center: "{{ he_data_center }}"
       name: "{{ he_cluster }}"
-      compatibility_version: "{{ he_compatibility_version | default(omit) }}"
+      compatibility_version: "{{ he_cluster_comp_version | default(omit) }}"
       auth: "{{ ovirt_auth }}"
       virt: true
       gluster: true


### PR DESCRIPTION
in the latest version of 4.4, we have a new data center and cluster compatibility version - 4.5  
by default, we use the latest data center and cluster compatibility version - 4.5
but we need also the option to define the hosted engine to stay with compatibility version 4.4